### PR TITLE
Fix `shared-action-workflows` typo

### DIFF
--- a/get-pr-info/README.md
+++ b/get-pr-info/README.md
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: get-pr-info
-        uses: rapidsai/shared-action-workflows/get-pr-info@main
+        uses: rapidsai/shared-actions/get-pr-info@main
       - run: echo "${RAPIDS_BASE_BRANCH}"
         env:
           RAPIDS_BASE_BRANCH: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.ref }}


### PR DESCRIPTION
The example in [`get-pr-info/README.md`](https://github.com/rapidsai/shared-actions/blob/branch-23.12/get-pr-info/README.md?plain=1#L24) should link to `shared-actions`, not `shared-action-workflows`.