### PR TITLE
Document `HUB_TOKEN` variable.

### DIFF
--- a/dockerhub-script/README.md
+++ b/dockerhub-script/README.md
@@ -8,6 +8,10 @@ This composite action generates a DockerHub token and runs a script with it. The
 - `DOCKERHUB_TOKEN` (required): DockerHub password
 - `script` (required): Script to run
 
+## Inner variables
+These are variables pre-computed by this action which become usable by the scripts that you pass to be run in this action. 
+- `HUB_TOKEN`: The generated dockerhub token required for authorization against the Dockerhub API.
+
 ## Usage
 
 ```yaml

--- a/dockerhub-script/README.md
+++ b/dockerhub-script/README.md
@@ -10,7 +10,7 @@ This composite action generates a DockerHub token and runs a script with it. The
 
 ## Inner variables
 These are variables pre-computed by this action which become usable by the scripts that you pass to be run in this action. 
-- `HUB_TOKEN`: The generated dockerhub token required for authorization against the Dockerhub API.
+- `HUB_TOKEN`: The generated DockerHub token required for authorization against the DockerHub API.
 
 ## Usage
 


### PR DESCRIPTION
Adds information about the inner variables of the `dockerhub-script` action which become subsequently available to any called scripts.