### PR TITLE
Add retries to `dockerhub-script`

### DIFF
--- a/dockerhub-script/README.md
+++ b/dockerhub-script/README.md
@@ -1,4 +1,4 @@
-# Get DockerHub Token
+# dockerhub-script
 
 This composite action generates a DockerHub token and runs a script with it. The token is revoked when the composite action exits.
 

--- a/dockerhub-script/action.yml
+++ b/dockerhub-script/action.yml
@@ -21,7 +21,7 @@ runs:
       shell: bash
       run: |
         logout() {
-          curl -X POST \
+          curl --silent -X POST \
             --retry 5 --retry-all-errors \
             -H "Authorization: JWT $HUB_TOKEN" \
             "https://hub.docker.com/v2/logout/"
@@ -30,7 +30,7 @@ runs:
         trap logout EXIT
 
         HUB_TOKEN=$(
-          curl -s -H "Content-Type: application/json" \
+          curl --silent -H "Content-Type: application/json" \
             --retry 5 --retry-all-errors \
             -X POST \
             -d "{\"username\": \"${DOCKERHUB_USER}\", \"password\": \"${DOCKERHUB_TOKEN}\"}" \

--- a/dockerhub-script/action.yml
+++ b/dockerhub-script/action.yml
@@ -22,6 +22,7 @@ runs:
       run: |
         logout() {
           curl -X POST \
+            --retry 5 --retry-all-errors \
             -H "Authorization: JWT $HUB_TOKEN" \
             "https://hub.docker.com/v2/logout/"
         }
@@ -30,6 +31,7 @@ runs:
 
         HUB_TOKEN=$(
           curl -s -H "Content-Type: application/json" \
+            --retry 5 --retry-all-errors \
             -X POST \
             -d "{\"username\": \"${DOCKERHUB_USER}\", \"password\": \"${DOCKERHUB_TOKEN}\"}" \
             https://hub.docker.com/v2/users/login/ | jq -r .token \

--- a/get-pr-info/README.md
+++ b/get-pr-info/README.md
@@ -1,4 +1,4 @@
-# shared-actions# get-pr-info
+# get-pr-info
 
 This composite action is intended to be used in workflows that run on `pull-request/<PR_NUMBER>` branches.
 


### PR DESCRIPTION
This PR adds some retries to the `dockerhub-script` action to handle transient network issues.

This change is similar to https://github.com/rapidsai/workflows/pull/51.