### PR TITLE
skip cert writing and variable setting if concat certs starts with ;

### DIFF
--- a/telemetry-impls/summarize/action.yml
+++ b/telemetry-impls/summarize/action.yml
@@ -40,7 +40,7 @@ runs:
     #    to avoid issues with quoting and multiline text.
     # If these env vars are not set, then otel-cli will not attempt to use mTLS.
     - name: Write certificate files for mTLS
-      if: "${{ inputs.cert_concat }} != ''"
+      if: ${{ !startsWith(inputs.cert_concat, ';') }}
       shell: bash
       run: |
         mkdir -p /tmp/certs


### PR DESCRIPTION
The problem being approached here is how to handle the absence of certificates. The input of certificates looks like:

```
        with:
          cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
```
If these secrets are not set, they'll just evaluate as empty, so our `cert_concat` value should come out looking like `;;`. This startsWith test should work, as should many other simple string comparisons. The cleanest way is probably to try a different way of setting the input to cert_concat, such that it is an empty string when the variables are not set. That is left for a future exercise, because this cert code is likely to go away soon anyway. We don't really want to be using certs.