### PR TITLE
Fix artifact cleanup

### DIFF
--- a/.github/workflows/test-artifact-cleanup.yml
+++ b/.github/workflows/test-artifact-cleanup.yml
@@ -1,6 +1,7 @@
 name: pr
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - "pull-request/[0-9]+"
@@ -20,4 +21,4 @@ jobs:
           name: telemetry-tools-attrs-1234
           path: file.txt
       - name: Telemetry setup
-        uses: ./shared-actions/telemetry-impls/clean-up-artifacts
+        uses: ./telemetry-impls/clean-up-artifacts

--- a/telemetry-impls/clean-up-artifacts/action.yml
+++ b/telemetry-impls/clean-up-artifacts/action.yml
@@ -40,14 +40,12 @@ runs:
             }
           }
 
-          console.log(artifacts)
-          for (const artifact in artifacts) {
-            console.log(artifact)
-            // if (artifact.name.startsWith("telemetry-tools-")) {
-            //   octokit.rest.actions.deleteArtifact({
-            //     context.repo.owner,
-            //     context.repo.repo,
-            //     artifact.id,
-            //   });
-            // }
-          }
+          artifacts.forEach(artifact => {
+            if (artifact.name.startsWith('telemetry-tools-')) {
+              github.rest.actions.deleteArtifact({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                artifact_id: artifact.id
+              });
+            }
+          });


### PR DESCRIPTION
Artifact cleanup removes all of the temporary "carrier" files that are created by each build job to transmit attribute values. Otherwise, these would be noisy and make it harder to find "real," interesting artifacts.