### PR TITLE
only run telemetry summary for run attempt = 1

### DIFF
--- a/telemetry-dispatch-summarize/action.yml
+++ b/telemetry-dispatch-summarize/action.yml
@@ -11,7 +11,9 @@ description: |
 runs:
   using: 'composite'
   steps:
+    - shell: bash
+      run: echo "test output to verify branch"
     - uses: rapidsai/shared-actions/telemetry-impls/load-then-clone@main
-      if: github.run_attempt == '1'
+      if: ${{ github.run_attempt == '1' }}
     - uses: ./shared-actions/telemetry-impls/summarize
-      if: github.run_attempt == '1'
+      if: ${{ github.run_attempt == '1' }}

--- a/telemetry-dispatch-summarize/action.yml
+++ b/telemetry-dispatch-summarize/action.yml
@@ -11,9 +11,10 @@ description: |
 runs:
   using: 'composite'
   steps:
-    - shell: bash
-      run: echo "test output to verify branch"
     - uses: rapidsai/shared-actions/telemetry-impls/load-then-clone@main
       if: ${{ github.run_attempt == '1' }}
     - uses: ./shared-actions/telemetry-impls/summarize
       if: ${{ github.run_attempt == '1' }}
+    - shell: bash
+      run: echo "Skipping telemetry summary on rerun jobs."
+      if: ${{ github.run_attempt != '1' }}

--- a/telemetry-dispatch-summarize/action.yml
+++ b/telemetry-dispatch-summarize/action.yml
@@ -12,4 +12,6 @@ runs:
   using: 'composite'
   steps:
     - uses: rapidsai/shared-actions/telemetry-impls/load-then-clone@main
+      if: github.run_attempt == '1'
     - uses: ./shared-actions/telemetry-impls/summarize
+      if: github.run_attempt == '1'


### PR DESCRIPTION
Discussions on Slack indicate that telemetry errors are confusing people. The likely issue is that re-runs are not handled well. The env vars file gets cleaned up at the end of the first run attempt, and does not get re-created.

This is a very simple approach: to skip telemetry on run attempts besides the first.