### PR TITLE
Never fail telemetry-summarize.

### DIFF
--- a/telemetry-impls/summarize/action.yml
+++ b/telemetry-impls/summarize/action.yml
@@ -36,6 +36,12 @@ runs:
       shell: bash
       run: |
         timeout 5m python3 ./shared-actions/telemetry-impls/summarize/send_trace.py
-
     - name: Clean up attributes artifacts from all jobs
       uses: ./shared-actions/telemetry-impls/clean-up-artifacts
+    # Telemetry jobs should never affect the pass/fail status of the overall CI
+    - name: Exit success
+      if: always()
+      continue-on-error: true
+      shell: bash
+      run: |
+        exit 0


### PR DESCRIPTION
Sometimes `telemetry-summarize` jobs fail for various reasons such as:

```
Error: Unable to download artifact(s): Artifact not found for name: telemetry-tools-env-vars
```

(I think this specific failure might be occurring when jobs are re-run due to failures such as network hiccups in the first pass.)

However, we never want telemetry jobs to affect the overall pass/fail status for a pull request because it reduces the signal/noise of the CI outputs and confuses many developers. This PR proposes a change to `telemetry-summarize` that makes the job never fail.
