### PR TITLE
correct handling of UCX branches in check-nightly-success

### DIFF
--- a/check_nightly_success/check-nightly-success/check.py
+++ b/check_nightly_success/check-nightly-success/check.py
@@ -51,7 +51,9 @@ def main(
 
     latest_success = {}
     for branch, branch_runs in itertools.groupby(runs, key=lambda r: r["head_branch"]):
-        if not re.match("branch-[0-9]{2}.[0-9]{2}", branch):
+        # only consider RAPIDS release branches, which have versions like
+        # '25.02' (RAPIDS) or '0.42' (ucxx, ucx-py)
+        if not re.match("branch-[0-9]{1,2}.[0-9]{2}", branch):
             continue
 
         latest_success[branch] = None


### PR DESCRIPTION
See https://github.com/rapidsai/ucxx/pull/347#issuecomment-2588096411

`check-nightly-sucess` uses a regex to determine whether or not a target branch is a release branch. That regex doesn't correctly handle branches like `branch-0.42` (used in projects like `ucxx` and `ucx-py`).

This fixes that.