### PR TITLE
Send trace tweaks

### DIFF
--- a/telemetry-impls/summarize/send_trace.py
+++ b/telemetry-impls/summarize/send_trace.py
@@ -11,125 +11,110 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Processes a GitHub Actions workflow log record and outputs OpenTelemetry span data."""
-
+"""Process a GitHub workflow log record and output OpenTelemetry span data."""
 
 from __future__ import annotations
-from datetime import datetime, timezone
+
 import hashlib
 import json
 import logging
 import os
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional, Dict
 
-from opentelemetry import trace
-from opentelemetry.context import attach, detach
-from opentelemetry.propagate import extract
-from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry import context, trace
 from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from opentelemetry.trace.status import StatusCode
 from opentelemetry.sdk.trace.id_generator import IdGenerator
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+from opentelemetry.trace.status import StatusCode
 
 match os.getenv("OTEL_EXPORTER_OTLP_PROTOCOL"):
     case "http/protobuf":
-        from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+            OTLPSpanExporter,
+        )
     case "grpc":
-        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+            OTLPSpanExporter,
+        )
     case _:
-        from opentelemetry.sdk.trace.export import ConsoleSpanExporter as OTLPSpanExporter
+        from opentelemetry.sdk.trace.export import (
+            ConsoleSpanExporter as OTLPSpanExporter,
+        )
 
 
-import logging
 logging.basicConfig(level=logging.WARNING)
 
 SpanProcessor = BatchSpanProcessor
 
 
-def parse_attribute_file(filename: str) -> Dict[str, str]:
+def parse_attributes(attrs: os.PathLike | str | None) -> dict[str, str]:
+    """Attempt to parse attributes in a given list `attrs`."""
+    attrs_list: list[str]
+    if not attrs:
+        return {}
+    try:
+        with Path(attrs).open() as attribute_file:
+            attrs_list = attribute_file.readlines()
+    except FileNotFoundError:
+        attrs_list = str(attrs).split(",")
     attributes = {}
-    with open(filename, "r") as attribute_file:
-        for line in attribute_file.readlines():
-            key, value = line.strip().split('=', 1)
-            attributes[key] = value
+    for attr in attrs_list:
+        key, value = attr.split("=", 1)
+        attributes[key] = value.strip().strip('"')
     return attributes
 
 
-def date_str_to_epoch(date_str: str, value_if_not_set: Optional[int] = 0) -> int:
+def date_str_to_epoch(date_str: str, value_if_not_set: int | None = 0) -> int:
+    """Github logs come in RFC 3339; this converts to nanoseconds since epoch."""
     if date_str:
         # replace bit is to attach the UTC timezone to our datetime object, so
         # that it doesn't "help" us by adjusting our string value, which is
         # already in UTC
-        timestamp_ns = int(datetime.strptime(date_str, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc).timestamp() * 1e9)
+        timestamp_ns = int(
+            datetime.strptime(date_str, "%Y-%m-%dT%H:%M:%SZ")
+            .replace(tzinfo=timezone.utc)
+            .timestamp()
+            * 1e9
+        )
     else:
         timestamp_ns = value_if_not_set or 0
     return timestamp_ns
 
 
 def map_conclusion_to_status_code(conclusion: str) -> StatusCode:
+    """Map string conclusion from logs to OTel enum."""
     if conclusion == "success":
         return StatusCode.OK
-    elif conclusion == "failure":
+    if conclusion == "failure":
         return StatusCode.ERROR
-    else:
-        return StatusCode.UNSET
+    return StatusCode.UNSET
 
-def load_env_vars():
-    env_vars = {}
-    with open('telemetry-artifacts/telemetry-env-vars') as f:
-        for line in f.readlines():
-            k, v = line.split("=", 1)
-            env_vars[k] = v.strip().strip('"')
-    return env_vars
-
-class LoadTraceParentGenerator(IdGenerator):
-    def __init__(self, traceparent) -> None:
-        # purpose of this is to keep the trace ID constant if the same data is sent different times,
-        # which mainly happens during testing. Having the trace ID be something that we control
-        # will also be useful for tying together logs and metrics with our traces.
-        ctx = extract(
-            carrier={'traceparent': traceparent},
-        )
-        self.context = list(ctx.values())[0].get_span_context()
-
-
-    def generate_span_id(self) -> int:
-        """Get a new span ID.
-
-        Returns:
-            A 64-bit int for use as a span ID
-        """
-        return self.context.span_id
-
-    def generate_trace_id(self) -> int:
-        """Get a new trace ID.
-
-        Implementations should at least make the 64 least significant bits
-        uniformly random. Samplers like the `TraceIdRatioBased` sampler rely on
-        this randomness to make sampling decisions.
-
-        See `the specification on TraceIdRatioBased <https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#traceidratiobased>`_.
-
-        Returns:
-            A 128-bit int for use as a trace ID
-        """
-        return self.context.trace_id
 
 class RapidsSpanIdGenerator(IdGenerator):
-    def __init__(self, trace_id, job_name) -> None:
+    """ID Generator that generates span IDs. Trace IDs come from elsewhere."""
+
+    def __init__(self, trace_id: int, job_name: str) -> None:
+        """Initialize generator with trace ID and initial job_name."""
         self.trace_id = trace_id
         self.job_name = job_name
         self.step_name = None
 
-    def update_step_name(self, step_name):
+    def update_job_name(self, job_name: str) -> None:
+        """Update the job name, which feeds into computing the span name."""
+        self.job_name = job_name
+
+    def update_step_name(self, step_name: str) -> None:
+        """Update the step name, which feeds into computing the span name."""
         self.step_name = step_name
 
     def generate_span_id(self) -> int:
         """Get a new span ID.
 
-        Returns:
-            A 64-bit int for use as a span ID
+        This is called by the OpenTelemetry SDK as-is, without arguments.
+        To change the generated value here, use the update methods.
         """
         span_id = hashlib.sha256()
         span_id.update(str(self.trace_id).encode())
@@ -139,92 +124,64 @@ class RapidsSpanIdGenerator(IdGenerator):
         return int(span_id.hexdigest()[:16], 16)
 
     def generate_trace_id(self) -> int:
-        """Get a new trace ID.
-
-        Implementations should at least make the 64 least significant bits
-        uniformly random. Samplers like the `TraceIdRatioBased` sampler rely on
-        this randomness to make sampling decisions.
-
-        See `the specification on TraceIdRatioBased <https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#traceidratiobased>`_.
-
-        Returns:
-            A 128-bit int for use as a trace ID
-        """
+        """Return the trace ID that is stored at initialization."""
         return self.trace_id
 
 
-class GithubActionsParserGenerator(IdGenerator):
-    def __init__(self, traceparent) -> None:
-        # purpose of this is to keep the trace ID constant if the same data is sent different times,
-        # which mainly happens during testing. Having the trace ID be something that we control
-        # will also be useful for tying together logs and metrics with our traces.
-        ctx = extract(
-            carrier={'traceparent': traceparent},
-        )
-        self.context = list(ctx.values())[0].get_span_context()
-
-    def update_span_job_name(self, new_name):
-        self.job_name = new_name
-
-    def update_span_step_name(self, new_name):
-        self.step_name = new_name
-
-
-    def generate_span_id(self) -> int:
-        """Get a new span ID.
-
-        Returns:
-            A 64-bit int for use as a span ID
-        """
-        return self.context.span_id
-
-    def generate_trace_id(self) -> int:
-        """Get a new trace ID.
-
-        Implementations should at least make the 64 least significant bits
-        uniformly random. Samplers like the `TraceIdRatioBased` sampler rely on
-        this randomness to make sampling decisions.
-
-        See `the specification on TraceIdRatioBased <https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#traceidratiobased>`_.
-
-        Returns:
-            A 128-bit int for use as a trace ID
-        """
-        return self.context.trace_id
-
-
-def main(args):
-    with open("all_jobs.json") as f:
+def main() -> None:
+    """Run core functionality."""
+    with Path("all_jobs.json").open() as f:
         jobs = json.loads(f.read())
 
-    env_vars = load_env_vars()
+    env_vars = parse_attributes("telemetry-artifacts/telemetry-env-vars")
 
     first_timestamp = date_str_to_epoch(jobs[0]["created_at"])
     # track the latest timestamp observed and use it for any unavailable times.
-    last_timestamp = date_str_to_epoch(jobs[0]["completed_at"])
+    last_timestamp = date_str_to_epoch(jobs[0]["completed_at"], 0)
 
-    attribute_files = list(Path.cwd().glob(f"telemetry-artifacts/attrs-*"))
+    attribute_files = list(Path.cwd().glob("telemetry-artifacts/attrs-*"))
     if attribute_files:
         attribute_file = attribute_files[0]
-        attributes = parse_attribute_file(attribute_file.as_posix())
+        attributes = parse_attributes(attribute_file.as_posix())
     else:
         attributes = {}
-    global_attrs = {}
-    for k, v in attributes.items():
-        if k.startswith('git.'):
-            global_attrs[k] = v
+    global_attrs = {k: v for k, v in attributes.items() if k.startswith("git.")}
+    global_attrs["service.name"] = env_vars["OTEL_SERVICE_NAME"]
 
-    global_attrs['service.name'] = env_vars['OTEL_SERVICE_NAME']
+    ctx = TraceContextTextMapPropagator().extract(
+        carrier={"traceparent": env_vars["TRACEPARENT"]},
+    )
+    context.attach(ctx)
+    trace_id = int(env_vars["TRACEPARENT"].split("-")[1], 16)
 
-    provider = TracerProvider(resource=Resource(global_attrs), id_generator=LoadTraceParentGenerator(env_vars["TRACEPARENT"]))
+    provider = TracerProvider(
+        resource=Resource(global_attrs),
+        id_generator=RapidsSpanIdGenerator(
+            trace_id=trace_id, job_name=env_vars["OTEL_SERVICE_NAME"]
+        ),
+    )
     provider.add_span_processor(span_processor=SpanProcessor(OTLPSpanExporter()))
-    tracer = trace.get_tracer("GitHub Actions parser", "0.0.1", tracer_provider=provider)
+    tracer = trace.get_tracer(
+        "GitHub Actions parser", "0.0.1", tracer_provider=provider
+    )
 
-    with tracer.start_as_current_span("workflow root", start_time=first_timestamp, end_on_exit=False) as root_span:
+    with tracer.start_as_current_span(
+        name="Top-level workflow root", start_time=first_timestamp, end_on_exit=False
+    ) as root_span:
         for job in jobs:
-            job_name = job["name"]
+            # This is the top-level workflow, which we account for with the root
+            # trace above
+            if job["name"] == env_vars["OTEL_SERVICE_NAME"]:
+                continue
+            # this cuts off matrix info from the job name, such that grafana can group
+            # these by name
+            if "/" in job["name"]:
+                job_name, matrix_part = job["name"].split("/", 1)
+            else:
+                job_name, matrix_part = job["name"], None
+
             job_id = job["id"]
-            logging.info(f"Processing job '{job_name}'")
+            logging.info("Processing job: %s", job_name)
             job_create = date_str_to_epoch(job["created_at"], first_timestamp)
             job_start = date_str_to_epoch(job["started_at"], first_timestamp)
             # this may get later in time as we progress through the steps. It is
@@ -233,60 +190,73 @@ def main(args):
             job_last_timestamp = date_str_to_epoch(job["completed_at"], job_start)
 
             if job_start == 0:
-                logging.info(f"Job is empty (no start time) - bypassing")
+                logging.info("Job is empty (no start time) - bypassing")
                 continue
 
             attribute_file = Path.cwd() / f"telemetry-artifacts/attrs-{job_id}"
             attributes = {}
             if attribute_file.exists():
-                logging.debug(f"Found attribute file for job '{job_id}'")
-                attributes = parse_attribute_file(attribute_file.as_posix())
+                logging.debug("Found attribute file for job: %s", job_id)
+                attributes = parse_attributes(attribute_file.as_posix())
             else:
-                logging.debug(f"No attribute metadata found for job '{job_id}'")
+                logging.debug("No attribute metadata found for job: %s", job_id)
 
             attributes["service.name"] = job_name
+            job_provider = TracerProvider(
+                resource=Resource(attributes),
+                id_generator=RapidsSpanIdGenerator(
+                    trace_id=trace_id, job_name=job["name"]
+                ),
+            )
+            job_provider.add_span_processor(
+                span_processor=SpanProcessor(OTLPSpanExporter())
+            )
+            job_tracer = trace.get_tracer(
+                "GitHub Actions parser", "0.0.1", tracer_provider=job_provider
+            )
 
-            job_id_generator = RapidsSpanIdGenerator(trace_id=root_span.get_span_context().trace_id, job_name=job_name)
-
-            job_provider = TracerProvider(resource=Resource(attributes=attributes), id_generator=job_id_generator)
-            job_provider.add_span_processor(span_processor=SpanProcessor(OTLPSpanExporter()))
-            job_tracer = trace.get_tracer("GitHub Actions parser", "0.0.1", tracer_provider=job_provider)
-
-            with job_tracer.start_as_current_span(job['name'], start_time=job_create, end_on_exit=False) as job_span:
+            with job_tracer.start_as_current_span(
+                name=matrix_part or job["name"],
+                start_time=job_create,
+                context=ctx,
+                end_on_exit=False,
+            ) as job_span:
                 job_span.set_status(map_conclusion_to_status_code(job["conclusion"]))
 
-                job_id_generator.update_step_name('start delay time')
-                with job_tracer.start_as_current_span(
-                        name="start delay time",
-                        start_time=job_create,
-                        end_on_exit=False,
-                        ) as delay_span:
-                    delay_span.end(job_start)
+                job_provider.id_generator.update_step_name("Start delay time")
+                delay_span = job_tracer.start_span(
+                    name="Start delay time", start_time=job_create
+                )
+                delay_span.end(job_start)
 
                 for step in job["steps"]:
                     start = date_str_to_epoch(step["started_at"], job_last_timestamp)
                     end = date_str_to_epoch(step["completed_at"], start)
-                    job_id_generator.update_step_name(step['name'])
+                    job_provider.id_generator.update_step_name(step["name"])
 
                     if (end - start) / 1e9 > 1:
-                        logging.info(f"processing step: '{step['name']}'")
-                        with job_tracer.start_as_current_span(
-                                name=step['name'],
-                                start_time=start,
-                                end_on_exit=False,
-                            ) as step_span:
-                            step_span.set_status(map_conclusion_to_status_code(step["conclusion"]))
-                            step_span.end(end)
+                        logging.info("processing step: %s", step["name"])
+                        job_provider.id_generator.update_step_name(step["name"])
+                        step_span = job_tracer.start_span(
+                            name=step["name"],
+                            start_time=start,
+                            attributes=attributes,
+                        )
+                        step_span.set_status(
+                            map_conclusion_to_status_code(step["conclusion"])
+                        )
+                        step_span.end(end)
 
                         job_last_timestamp = max(end, job_last_timestamp)
 
-                job_end = max(date_str_to_epoch(job["completed_at"], job_last_timestamp), job_last_timestamp)
-                last_timestamp = max(job_end, last_timestamp)
+                    job_end = max(
+                        date_str_to_epoch(job["completed_at"], job_last_timestamp),
+                        job_last_timestamp,
+                    )
+                    last_timestamp = max(job_end, last_timestamp)
                 job_span.end(job_end)
         root_span.end(last_timestamp)
 
 
 if __name__ == "__main__":
-    import sys
-
-    main(sys.argv[1:])
+    main()

--- a/telemetry-impls/summarize/send_trace.py
+++ b/telemetry-impls/summarize/send_trace.py
@@ -21,6 +21,7 @@ import logging
 import os
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from opentelemetry import context, trace
 from opentelemetry.sdk.resources import Resource
@@ -29,6 +30,12 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.sdk.trace.id_generator import IdGenerator
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 from opentelemetry.trace.status import StatusCode
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from typing import Any
+
+    from opentelemetry.context import Context
 
 match os.getenv("OTEL_EXPORTER_OTLP_PROTOCOL"):
     case "http/protobuf":
@@ -128,6 +135,98 @@ class RapidsSpanIdGenerator(IdGenerator):
         return self.trace_id
 
 
+def process_job_blob(  # noqa: PLR0913
+    trace_id: int,
+    ctx: Context,
+    job: Mapping[str, Any],
+    env_vars: Mapping[str, str],
+    first_timestamp: int,
+    last_timestamp: int,
+) -> int:
+    """Transform job JSON into an OTel span."""
+    # This is the top-level workflow, which we account for with the root
+    # trace above
+    if job["name"] == env_vars["OTEL_SERVICE_NAME"]:
+        return last_timestamp
+    # this cuts off matrix info from the job name, such that grafana can group
+    # these by name
+    if "/" in job["name"]:
+        job_name, matrix_part = job["name"].split("/", 1)
+    else:
+        job_name, matrix_part = job["name"], None
+
+    job_id = job["id"]
+    logging.info("Processing job: %s", job_name)
+    job_create = date_str_to_epoch(job["created_at"], first_timestamp)
+    job_start = date_str_to_epoch(job["started_at"], first_timestamp)
+    # this may get later in time as we progress through the steps. It is
+    # common to have the job completion time be earlier than the end of
+    # the final cleanup steps
+    job_last_timestamp = date_str_to_epoch(job["completed_at"], job_start)
+
+    if job_start == 0:
+        logging.info("Job is empty (no start time) - bypassing")
+        return last_timestamp
+
+    attribute_file = Path.cwd() / f"telemetry-artifacts/attrs-{job_id}"
+    attributes = {}
+    if attribute_file.exists():
+        logging.debug("Found attribute file for job: %s", job_id)
+        attributes = parse_attributes(attribute_file.as_posix())
+    else:
+        logging.debug("No attribute metadata found for job: %s", job_id)
+
+    attributes["service.name"] = job_name
+    job_provider = TracerProvider(
+        resource=Resource(attributes),
+        id_generator=RapidsSpanIdGenerator(trace_id=trace_id, job_name=job["name"]),
+    )
+    job_provider.add_span_processor(span_processor=SpanProcessor(OTLPSpanExporter()))
+    job_tracer = trace.get_tracer(
+        "GitHub Actions parser", "0.0.1", tracer_provider=job_provider
+    )
+
+    with job_tracer.start_as_current_span(
+        name=matrix_part or job["name"],
+        start_time=job_create,
+        context=ctx,
+        end_on_exit=False,
+    ) as job_span:
+        job_span.set_status(map_conclusion_to_status_code(job["conclusion"]))
+
+        job_provider.id_generator.update_step_name("Start delay time")
+        delay_span = job_tracer.start_span(
+            name="Start delay time", start_time=job_create
+        )
+        delay_span.end(job_start)
+
+        for step in job["steps"]:
+            start = date_str_to_epoch(step["started_at"], job_last_timestamp)
+            end = date_str_to_epoch(step["completed_at"], start)
+            job_provider.id_generator.update_step_name(step["name"])
+
+            if (end - start) / 1e9 > 1:
+                logging.info("processing step: %s", step["name"])
+                job_provider.id_generator.update_step_name(step["name"])
+                step_span = job_tracer.start_span(
+                    name=step["name"],
+                    start_time=start,
+                    attributes=attributes,
+                )
+                step_span.set_status(map_conclusion_to_status_code(step["conclusion"]))
+                step_span.end(end)
+
+                job_last_timestamp = max(end, job_last_timestamp)
+
+            job_end = max(
+                date_str_to_epoch(job["completed_at"], job_last_timestamp),
+                job_last_timestamp,
+            )
+            last_timestamp = max(job_end, last_timestamp)
+        job_span.end(job_end)
+    return last_timestamp
+
+
 def main() -> None:
     """Run core functionality."""
     with Path("all_jobs.json").open() as f:
@@ -169,92 +268,14 @@ def main() -> None:
         name="Top-level workflow root", start_time=first_timestamp, end_on_exit=False
     ) as root_span:
         for job in jobs:
-            # This is the top-level workflow, which we account for with the root
-            # trace above
-            if job["name"] == env_vars["OTEL_SERVICE_NAME"]:
-                continue
-            # this cuts off matrix info from the job name, such that grafana can group
-            # these by name
-            if "/" in job["name"]:
-                job_name, matrix_part = job["name"].split("/", 1)
-            else:
-                job_name, matrix_part = job["name"], None
-
-            job_id = job["id"]
-            logging.info("Processing job: %s", job_name)
-            job_create = date_str_to_epoch(job["created_at"], first_timestamp)
-            job_start = date_str_to_epoch(job["started_at"], first_timestamp)
-            # this may get later in time as we progress through the steps. It is
-            # common to have the job completion time be earlier than the end of
-            # the final cleanup steps
-            job_last_timestamp = date_str_to_epoch(job["completed_at"], job_start)
-
-            if job_start == 0:
-                logging.info("Job is empty (no start time) - bypassing")
-                continue
-
-            attribute_file = Path.cwd() / f"telemetry-artifacts/attrs-{job_id}"
-            attributes = {}
-            if attribute_file.exists():
-                logging.debug("Found attribute file for job: %s", job_id)
-                attributes = parse_attributes(attribute_file.as_posix())
-            else:
-                logging.debug("No attribute metadata found for job: %s", job_id)
-
-            attributes["service.name"] = job_name
-            job_provider = TracerProvider(
-                resource=Resource(attributes),
-                id_generator=RapidsSpanIdGenerator(
-                    trace_id=trace_id, job_name=job["name"]
-                ),
+            last_timestamp = process_job_blob(
+                trace_id=trace_id,
+                ctx=ctx,
+                job=job,
+                env_vars=env_vars,
+                first_timestamp=first_timestamp,
+                last_timestamp=last_timestamp,
             )
-            job_provider.add_span_processor(
-                span_processor=SpanProcessor(OTLPSpanExporter())
-            )
-            job_tracer = trace.get_tracer(
-                "GitHub Actions parser", "0.0.1", tracer_provider=job_provider
-            )
-
-            with job_tracer.start_as_current_span(
-                name=matrix_part or job["name"],
-                start_time=job_create,
-                context=ctx,
-                end_on_exit=False,
-            ) as job_span:
-                job_span.set_status(map_conclusion_to_status_code(job["conclusion"]))
-
-                job_provider.id_generator.update_step_name("Start delay time")
-                delay_span = job_tracer.start_span(
-                    name="Start delay time", start_time=job_create
-                )
-                delay_span.end(job_start)
-
-                for step in job["steps"]:
-                    start = date_str_to_epoch(step["started_at"], job_last_timestamp)
-                    end = date_str_to_epoch(step["completed_at"], start)
-                    job_provider.id_generator.update_step_name(step["name"])
-
-                    if (end - start) / 1e9 > 1:
-                        logging.info("processing step: %s", step["name"])
-                        job_provider.id_generator.update_step_name(step["name"])
-                        step_span = job_tracer.start_span(
-                            name=step["name"],
-                            start_time=start,
-                            attributes=attributes,
-                        )
-                        step_span.set_status(
-                            map_conclusion_to_status_code(step["conclusion"])
-                        )
-                        step_span.end(end)
-
-                        job_last_timestamp = max(end, job_last_timestamp)
-
-                    job_end = max(
-                        date_str_to_epoch(job["completed_at"], job_last_timestamp),
-                        job_last_timestamp,
-                    )
-                    last_timestamp = max(job_end, last_timestamp)
-                job_span.end(job_end)
         root_span.end(last_timestamp)
 
 


### PR DESCRIPTION
This refactors the traces/spans such that they will be more readily group-able in Grafana. Grafana's string mangling functionality is sorely lacking.

What exists before this PR:

![ungrouped](https://github.com/user-attachments/assets/3d5a079a-bf59-4e97-9c98-af90f9c56d80)

What you should pay attention to is the separate color blocks. You can't easily group the spans from a given shared workflow, such as the build-cpp-conda or devcontainer. Those have names that include the matrix elements, so grouping by job name ignoring matrix elements is impossible. We have the matrix elements in separate columns, so this is not info that we're losing.

The result of this refactor is that we can group by job name (by splitting the job name on the slash).

![2025-02-03_15-56](https://github.com/user-attachments/assets/189a0a2e-002c-48af-8aa2-d4449d952526)

The color blocks show the grouping that is now possible, while also preserving the parent relationship of the steps with a particular matrix job.