### PR TITLE
fix end time where no spans >1sec; simplify end variables

### DIFF
--- a/telemetry-impls/summarize/send_trace.py
+++ b/telemetry-impls/summarize/send_trace.py
@@ -196,6 +196,7 @@ def process_job_blob(  # noqa: PLR0913
         for step in job["steps"]:
             start = date_str_to_epoch(step["started_at"], job_last_timestamp)
             end = date_str_to_epoch(step["completed_at"], start)
+            job_last_timestamp = max(end, job_last_timestamp)
             job_provider.id_generator.update_step_name(step["name"])
 
             if (end - start) / 1e9 > 1:
@@ -208,8 +209,6 @@ def process_job_blob(  # noqa: PLR0913
                 )
                 step_span.set_status(map_conclusion_to_status_code(step["conclusion"]))
                 step_span.end(end)
-
-            job_last_timestamp = max(end, job_last_timestamp)
         last_timestamp = max(job_last_timestamp, last_timestamp)
         job_span.end(job_last_timestamp)
     return last_timestamp

--- a/telemetry-impls/summarize/send_trace.py
+++ b/telemetry-impls/summarize/send_trace.py
@@ -209,14 +209,9 @@ def process_job_blob(  # noqa: PLR0913
                 step_span.set_status(map_conclusion_to_status_code(step["conclusion"]))
                 step_span.end(end)
 
-                job_last_timestamp = max(end, job_last_timestamp)
-
-            job_end = max(
-                date_str_to_epoch(job["completed_at"], job_last_timestamp),
-                job_last_timestamp,
-            )
-            last_timestamp = max(job_end, last_timestamp)
-        job_span.end(job_end)
+            job_last_timestamp = max(end, job_last_timestamp)
+        last_timestamp = max(job_last_timestamp, last_timestamp)
+        job_span.end(job_last_timestamp)
     return last_timestamp
 
 


### PR DESCRIPTION
There was a bug in #40 where if all spans in a job were less than 1 second, the job_end would never get set. This PR gets rid of job_end completely and uses the job_last_timestamp, which is always set at least in the top of the function.