### PR TITLE
Exempt new workflows from check-nightly-success.

### DIFF
--- a/check_nightly_success/check-nightly-success/check.py
+++ b/check_nightly_success/check-nightly-success/check.py
@@ -111,7 +111,7 @@ def main(
         print(  # noqa: T201
             f"The oldest run of the {workflow_id} workflow on {latest_branch} was less "
             f"than {max_days_without_success} days ago. This exempts the workflow from "
-            "check-nightly-success, because the workflow has not been running for very long."
+            "check-nightly-success because the workflow has not been running for very long."
         )
         return 0
 


### PR DESCRIPTION
Nightly CI often fails when we roll over to a new branch. This is currently blocking CI on branch-25.04.

We should exempt our nightly workflows when they have been running for less than `max_days_without_success`.
