### PR TITLE
disable telemetry-summarize functionality when run_attempt >1

### DIFF
--- a/telemetry-dispatch-summarize/action.yml
+++ b/telemetry-dispatch-summarize/action.yml
@@ -15,3 +15,6 @@ runs:
       if: ${{ github.run_attempt == '1' }}
     - uses: ./shared-actions/telemetry-impls/summarize
       if: ${{ github.run_attempt == '1' }}
+    - if: ${{ github.run_attempt != '1' }}
+      shell: bash
+      run: echo "Skipping telemetry-summarize for run attempt > 1"

--- a/telemetry-dispatch-summarize/action.yml
+++ b/telemetry-dispatch-summarize/action.yml
@@ -12,4 +12,6 @@ runs:
   using: 'composite'
   steps:
     - uses: rapidsai/shared-actions/telemetry-impls/load-then-clone@main
+      if: ${{ github.run_attempt == '1' }}
     - uses: ./shared-actions/telemetry-impls/summarize
+      if: ${{ github.run_attempt == '1' }}


### PR DESCRIPTION
This is still causing trouble because while the shared-workflows calls have this check, the PR.yaml root workflow calls directly to the action do not.