### PR TITLE
check for env var artifact before download to avoid error noise

### DIFF
--- a/telemetry-dispatch-setup/action.yml
+++ b/telemetry-dispatch-setup/action.yml
@@ -11,6 +11,9 @@ description: |
   step in any job other than computing the matrix.
 
 inputs:
+  GH_TOKEN:
+    required: true
+    description: "GitHub token to use to check for artifact"
   extra_attributes:
     description: "comma-separated key=value attributes to associate with the current job"
 
@@ -18,6 +21,8 @@ runs:
   using: 'composite'
   steps:
     - uses: rapidsai/shared-actions/telemetry-impls/load-then-clone@check-base-env-var-artifact
+      with:
+        GH_TOKEN: ${{ inputs.GH_TOKEN }}
     - name: Creating folder for job-created telemetry artifacts
       shell: bash
       run: mkdir -p telemetry-artifacts

--- a/telemetry-dispatch-setup/action.yml
+++ b/telemetry-dispatch-setup/action.yml
@@ -20,7 +20,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: rapidsai/shared-actions/telemetry-impls/load-then-clone@check-base-env-var-artifact
+    - uses: rapidsai/shared-actions/telemetry-impls/load-then-clone@main
       id: has_base_env_var_artifact
       with:
         GH_TOKEN: ${{ inputs.GH_TOKEN }}

--- a/telemetry-dispatch-setup/action.yml
+++ b/telemetry-dispatch-setup/action.yml
@@ -24,6 +24,10 @@ runs:
       id: has_base_env_var_artifact
       with:
         GH_TOKEN: ${{ inputs.GH_TOKEN }}
+    - name: Output that setup was skipped if the base env var artifact was not found
+      if: steps.has_base_env_var_artifact.outputs.artifact_found == 'false'
+      shell: bash
+      run: echo "Skipping telemetry-setup because base env var artifact was not found"
     - name: Creating folder for job-created telemetry artifacts
       shell: bash
       run: mkdir -p telemetry-artifacts

--- a/telemetry-dispatch-setup/action.yml
+++ b/telemetry-dispatch-setup/action.yml
@@ -21,19 +21,25 @@ runs:
   using: 'composite'
   steps:
     - uses: rapidsai/shared-actions/telemetry-impls/load-then-clone@check-base-env-var-artifact
+      id: has_base_env_var_artifact
       with:
         GH_TOKEN: ${{ inputs.GH_TOKEN }}
     - name: Creating folder for job-created telemetry artifacts
+      if: steps.has_base_env_var_artifact.outputs.artifact_found == 'true'
       shell: bash
       run: mkdir -p telemetry-artifacts
     - uses: ./shared-actions/telemetry-impls/github-actions-job-info
+      if: steps.has_base_env_var_artifact.outputs.artifact_found == 'true'
     - shell: bash
+      if: steps.has_base_env_var_artifact.outputs.artifact_found == 'true'
       run:
         echo JOB_ID="$(cat job_info.json | jq -r '.id')" >> ${GITHUB_ENV};
     # overrides loaded value.
     - name: Set OTEL_SERVICE_NAME from job
+      if: steps.has_base_env_var_artifact.outputs.artifact_found == 'true'
       uses: ./shared-actions/telemetry-impls/set-otel-service-name
     - name: Add attribute metadata beyond the stashed basic stuff
+      if: steps.has_base_env_var_artifact.outputs.artifact_found == 'true'
       shell: bash
       run:
         attributes="${OTEL_RESOURCE_ATTRIBUTES}";

--- a/telemetry-dispatch-setup/action.yml
+++ b/telemetry-dispatch-setup/action.yml
@@ -25,7 +25,6 @@ runs:
       with:
         GH_TOKEN: ${{ inputs.GH_TOKEN }}
     - name: Creating folder for job-created telemetry artifacts
-      if: steps.has_base_env_var_artifact.outputs.artifact_found == 'true'
       shell: bash
       run: mkdir -p telemetry-artifacts
     - uses: ./shared-actions/telemetry-impls/github-actions-job-info

--- a/telemetry-dispatch-setup/action.yml
+++ b/telemetry-dispatch-setup/action.yml
@@ -11,9 +11,6 @@ description: |
   step in any job other than computing the matrix.
 
 inputs:
-  GH_TOKEN:
-    required: true
-    description: "GitHub token to use to check for artifact"
   extra_attributes:
     description: "comma-separated key=value attributes to associate with the current job"
 
@@ -22,8 +19,6 @@ runs:
   steps:
     - uses: rapidsai/shared-actions/telemetry-impls/load-then-clone@main
       id: has_base_env_var_artifact
-      with:
-        GH_TOKEN: ${{ inputs.GH_TOKEN }}
     - name: Output that setup was skipped if the base env var artifact was not found
       if: steps.has_base_env_var_artifact.outputs.artifact_found == 'false'
       shell: bash

--- a/telemetry-dispatch-setup/action.yml
+++ b/telemetry-dispatch-setup/action.yml
@@ -17,7 +17,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: rapidsai/shared-actions/telemetry-impls/load-then-clone@main
+    - uses: rapidsai/shared-actions/telemetry-impls/load-then-clone@check-base-env-var-artifact
     - name: Creating folder for job-created telemetry artifacts
       shell: bash
       run: mkdir -p telemetry-artifacts

--- a/telemetry-dispatch-stash-job-artifacts/action.yml
+++ b/telemetry-dispatch-stash-job-artifacts/action.yml
@@ -16,8 +16,10 @@ runs:
   using: 'composite'
   steps:
     - uses: rapidsai/shared-actions/telemetry-impls/load-then-clone@check-base-env-var-artifact
+      id: has_base_env_var_artifact
       with:
         GH_TOKEN: ${{ inputs.GH_TOKEN }}
     # Stash current job's OTEL_RESOURCE_ATTRIBUTES and any files in the telemetry-artifacts directory
     - name: Stash job artifacts
       uses: ./shared-actions/telemetry-impls/stash-job-artifacts
+      if: steps.has_base_env_var_artifact.outputs.artifact_found == 'true'

--- a/telemetry-dispatch-stash-job-artifacts/action.yml
+++ b/telemetry-dispatch-stash-job-artifacts/action.yml
@@ -7,10 +7,17 @@ description: |
   Inputs here are all assumed to be env vars set outside of this script.
   Set them in your main repo's workflows (export to ${GITHUB_ENV}!!)
 
+inputs:
+  GH_TOKEN:
+    required: true
+    description: "GitHub token to use to check for artifact"
+
 runs:
   using: 'composite'
   steps:
     - uses: rapidsai/shared-actions/telemetry-impls/load-then-clone@check-base-env-var-artifact
+      with:
+        GH_TOKEN: ${{ inputs.GH_TOKEN }}
     # Stash current job's OTEL_RESOURCE_ATTRIBUTES and any files in the telemetry-artifacts directory
     - name: Stash job artifacts
       uses: ./shared-actions/telemetry-impls/stash-job-artifacts

--- a/telemetry-dispatch-stash-job-artifacts/action.yml
+++ b/telemetry-dispatch-stash-job-artifacts/action.yml
@@ -10,7 +10,7 @@ description: |
 runs:
   using: 'composite'
   steps:
-    - uses: rapidsai/shared-actions/telemetry-impls/load-then-clone@main
+    - uses: rapidsai/shared-actions/telemetry-impls/load-then-clone@check-base-env-var-artifact
     # Stash current job's OTEL_RESOURCE_ATTRIBUTES and any files in the telemetry-artifacts directory
     - name: Stash job artifacts
       uses: ./shared-actions/telemetry-impls/stash-job-artifacts

--- a/telemetry-dispatch-stash-job-artifacts/action.yml
+++ b/telemetry-dispatch-stash-job-artifacts/action.yml
@@ -7,18 +7,11 @@ description: |
   Inputs here are all assumed to be env vars set outside of this script.
   Set them in your main repo's workflows (export to ${GITHUB_ENV}!!)
 
-inputs:
-  GH_TOKEN:
-    required: true
-    description: "GitHub token to use to check for artifact"
-
 runs:
   using: 'composite'
   steps:
     - uses: rapidsai/shared-actions/telemetry-impls/load-then-clone@main
       id: has_base_env_var_artifact
-      with:
-        GH_TOKEN: ${{ inputs.GH_TOKEN }}
     # Stash current job's OTEL_RESOURCE_ATTRIBUTES and any files in the telemetry-artifacts directory
     - name: Stash job artifacts
       uses: ./shared-actions/telemetry-impls/stash-job-artifacts

--- a/telemetry-dispatch-stash-job-artifacts/action.yml
+++ b/telemetry-dispatch-stash-job-artifacts/action.yml
@@ -15,7 +15,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: rapidsai/shared-actions/telemetry-impls/load-then-clone@check-base-env-var-artifact
+    - uses: rapidsai/shared-actions/telemetry-impls/load-then-clone@main
       id: has_base_env_var_artifact
       with:
         GH_TOKEN: ${{ inputs.GH_TOKEN }}

--- a/telemetry-dispatch-stash-job-artifacts/action.yml
+++ b/telemetry-dispatch-stash-job-artifacts/action.yml
@@ -23,3 +23,7 @@ runs:
     - name: Stash job artifacts
       uses: ./shared-actions/telemetry-impls/stash-job-artifacts
       if: steps.has_base_env_var_artifact.outputs.artifact_found == 'true'
+    - name: Output that setup was skipped if the base env var artifact was not found
+      if: steps.has_base_env_var_artifact.outputs.artifact_found == 'false'
+      shell: bash
+      run: echo "Skipping telemetry-stash-job-artifacts because base env var artifact was not found"

--- a/telemetry-dispatch-summarize/action.yml
+++ b/telemetry-dispatch-summarize/action.yml
@@ -16,7 +16,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: rapidsai/shared-actions/telemetry-impls/load-then-clone@check-base-env-var-artifact
+    - uses: rapidsai/shared-actions/telemetry-impls/load-then-clone@main
       id: has_base_env_var_artifact
       with:
         GH_TOKEN: ${{ inputs.GH_TOKEN }}

--- a/telemetry-dispatch-summarize/action.yml
+++ b/telemetry-dispatch-summarize/action.yml
@@ -8,18 +8,11 @@ description: |
   with the timing and label metadata, and sends it to the configured Tempo
   endpoint (or forwarder).
 
-inputs:
-  GH_TOKEN:
-    required: true
-    description: "GitHub token to use to check for artifact"
-
 runs:
   using: 'composite'
   steps:
     - uses: rapidsai/shared-actions/telemetry-impls/load-then-clone@main
       id: has_base_env_var_artifact
-      with:
-        GH_TOKEN: ${{ inputs.GH_TOKEN }}
     - uses: ./shared-actions/telemetry-impls/summarize
       if: steps.has_base_env_var_artifact.outputs.artifact_found == 'true'
     - if: steps.has_base_env_var_artifact.outputs.artifact_found == 'false'

--- a/telemetry-dispatch-summarize/action.yml
+++ b/telemetry-dispatch-summarize/action.yml
@@ -11,7 +11,7 @@ description: |
 runs:
   using: 'composite'
   steps:
-    - uses: rapidsai/shared-actions/telemetry-impls/load-then-clone@main
+    - uses: rapidsai/shared-actions/telemetry-impls/load-then-clone@check-base-env-var-artifact
       if: ${{ github.run_attempt == '1' }}
     - uses: ./shared-actions/telemetry-impls/summarize
       if: ${{ github.run_attempt == '1' }}

--- a/telemetry-dispatch-summarize/action.yml
+++ b/telemetry-dispatch-summarize/action.yml
@@ -8,11 +8,18 @@ description: |
   with the timing and label metadata, and sends it to the configured Tempo
   endpoint (or forwarder).
 
+inputs:
+  GH_TOKEN:
+    required: true
+    description: "GitHub token to use to check for artifact"
+
 runs:
   using: 'composite'
   steps:
     - uses: rapidsai/shared-actions/telemetry-impls/load-then-clone@check-base-env-var-artifact
       if: ${{ github.run_attempt == '1' }}
+      with:
+        GH_TOKEN: ${{ inputs.GH_TOKEN }}
     - uses: ./shared-actions/telemetry-impls/summarize
       if: ${{ github.run_attempt == '1' }}
     - if: ${{ github.run_attempt != '1' }}

--- a/telemetry-dispatch-summarize/action.yml
+++ b/telemetry-dispatch-summarize/action.yml
@@ -17,11 +17,11 @@ runs:
   using: 'composite'
   steps:
     - uses: rapidsai/shared-actions/telemetry-impls/load-then-clone@check-base-env-var-artifact
-      if: ${{ github.run_attempt == '1' }}
+      id: has_base_env_var_artifact
       with:
         GH_TOKEN: ${{ inputs.GH_TOKEN }}
     - uses: ./shared-actions/telemetry-impls/summarize
-      if: ${{ github.run_attempt == '1' }}
-    - if: ${{ github.run_attempt != '1' }}
+      if: steps.has_base_env_var_artifact.outputs.artifact_found == 'true'
+    - if: steps.has_base_env_var_artifact.outputs.artifact_found == 'false'
       shell: bash
-      run: echo "Skipping telemetry-summarize for run attempt > 1"
+      run: echo "Skipping telemetry-summarize because base env var artifact was not found"

--- a/telemetry-impls/load-then-clone/action.yml
+++ b/telemetry-impls/load-then-clone/action.yml
@@ -28,19 +28,18 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.GH_TOKEN }}
       run: |
-        artifact_not_found=$(gh api repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts --jq '.artifacts[] | select(.name=="telemetry-tools-env-vars")' | grep -q . && echo '0' || echo '1');
-        echo "artifact_not_found=${artifact_not_found}" >> $GITHUB_OUTPUT;
-        echo "artifact_not_found=${artifact_not_found}"
+        artifact_found=$(gh api repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts --jq '.artifacts[] | select(.name=="telemetry-tools-env-vars")' | grep -q . && echo 'true' || echo 'false');
+        echo "artifact_found=${artifact_found}" | tee -a $GITHUB_OUTPUT;
     - name: Download base environment variables file
       uses: actions/download-artifact@v4
-      if: steps.check-artifact-exists.outputs.artifact_not_found == '1'
+      if: steps.check-artifact-exists.outputs.artifact_found == 'true'
       with:
         name: telemetry-tools-env-vars
         path: telemetry-artifacts
     # We can't use ./telemetry-implementation/load-base-env-vars here
     # because at this point we have not cloned the repo.
     - name: Set environment variables from file into GITHUB_ENV
-      if: steps.check-artifact-exists.outputs.artifact_not_found == '1'
+      if: steps.check-artifact-exists.outputs.artifact_found == 'true'
       shell: bash
       # Only set the env var if it is not already set
       # the ${!VARIABLE} syntax is called "indirect expansion" and it is kind of equivalent to ${${env_var_name}}

--- a/telemetry-impls/load-then-clone/action.yml
+++ b/telemetry-impls/load-then-clone/action.yml
@@ -17,34 +17,36 @@ description: |
 runs:
   using: 'composite'
   steps:
+    - name: Check if artifact exists
+      id: check-artifact-exists
+      run: |
+        gh api repos/rapidsai/cuml/actions/runs/${GITHUB_RUN_ID}/artifacts --jq '.artifacts[] | select(.name=="telemetry-tools-env-vars")' | grep -q .;
+        echo "artifact_not_found=$?" >> $GITHUB_OUTPUT
     - name: Download base environment variables file
       uses: actions/download-artifact@v4
+      if: steps.check-artifact-exists.outputs.artifact_not_found == '1'
       with:
         name: telemetry-tools-env-vars
         path: telemetry-artifacts
     # We can't use ./telemetry-implementation/load-base-env-vars here
     # because at this point we have not cloned the repo.
     - name: Set environment variables from file into GITHUB_ENV
+      if: steps.check-artifact-exists.outputs.artifact_not_found == '1'
       shell: bash
       # Only set the env var if it is not already set
       # the ${!VARIABLE} syntax is called "indirect expansion" and it is kind of equivalent to ${${env_var_name}}
       #      in other words, expand to find the variable name, then dereference that variable name
       # The goofy env_var_value filtering through tr is to ensure that the strings don't include quotes.
       run: |
-        gh api repos/rapidsai/cuml/actions/runs/${GITHUB_RUN_ID}/artifacts --jq '.artifacts[] | select(.name=="telemetry-tools-env-vars")' | grep -q .;
-        if [ $? -eq 0 ]; then
-          while read LINE; do
-            env_var_name="$( cut -d '=' -f 1 <<< "$LINE" )";
-            if [ "${!env_var_name}" = "" ]; then
-              env_var_value="$(echo ${LINE#*=} | tr -d '"')"
-              echo "${env_var_name}=$(echo "${env_var_value}" | sed 's/^,//')" >> ${GITHUB_ENV};
-            else
-              echo "Load base env info: ignoring new value for "${env_var_name}" in loading base env vars. It is already set to "${!env_var_name}"." >&2;
-            fi
-          done <telemetry-artifacts/telemetry-env-vars
-        else
-          echo "Load base env info: no telemetry-tools-env-vars artifact found - using default values" >&2;
-        fi
+        while read LINE; do
+          env_var_name="$( cut -d '=' -f 1 <<< "$LINE" )";
+          if [ "${!env_var_name}" = "" ]; then
+            env_var_value="$(echo ${LINE#*=} | tr -d '"')"
+            echo "${env_var_name}=$(echo "${env_var_value}" | sed 's/^,//')" >> ${GITHUB_ENV};
+          else
+            echo "Load base env info: ignoring new value for "${env_var_name}" in loading base env vars. It is already set to "${!env_var_name}"." >&2;
+          fi
+        done <telemetry-artifacts/telemetry-env-vars
     - name: Clone shared-actions repo with loaded env vars
       uses: actions/checkout@v4
       with:

--- a/telemetry-impls/load-then-clone/action.yml
+++ b/telemetry-impls/load-then-clone/action.yml
@@ -28,8 +28,7 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.GH_TOKEN }}
       run: |
-        gh api repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts --jq '.artifacts[] | select(.name=="telemetry-tools-env-vars")' | grep -q .;
-        echo "artifact_not_found=$?" >> $GITHUB_OUTPUT
+        echo "artifact_not_found=$(gh api repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts --jq '.artifacts[] | select(.name=="telemetry-tools-env-vars")' | grep -q . && echo '0' || echo '1')" >> $GITHUB_OUTPUT;
     - name: Download base environment variables file
       uses: actions/download-artifact@v4
       if: steps.check-artifact-exists.outputs.artifact_not_found == '1'

--- a/telemetry-impls/load-then-clone/action.yml
+++ b/telemetry-impls/load-then-clone/action.yml
@@ -28,7 +28,7 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.GH_TOKEN }}
       run: |
-        gh api repos/rapidsai/cuml/actions/runs/${GITHUB_RUN_ID}/artifacts --jq '.artifacts[] | select(.name=="telemetry-tools-env-vars")' | grep -q .;
+        gh api repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts --jq '.artifacts[] | select(.name=="telemetry-tools-env-vars")' | grep -q .;
         echo "artifact_not_found=$?" >> $GITHUB_OUTPUT
     - name: Download base environment variables file
       uses: actions/download-artifact@v4

--- a/telemetry-impls/load-then-clone/action.yml
+++ b/telemetry-impls/load-then-clone/action.yml
@@ -14,12 +14,19 @@ description: |
   As a result, we clone the code twice: first to learn how to load the variables,
   then another time when the variables are actually set.
 
+inputs:
+  GH_TOKEN:
+    required: true
+    description: "GitHub token to use to check for artifact"
+
 runs:
   using: 'composite'
   steps:
     - name: Check if artifact exists
       id: check-artifact-exists
       shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.GH_TOKEN }}
       run: |
         gh api repos/rapidsai/cuml/actions/runs/${GITHUB_RUN_ID}/artifacts --jq '.artifacts[] | select(.name=="telemetry-tools-env-vars")' | grep -q .;
         echo "artifact_not_found=$?" >> $GITHUB_OUTPUT

--- a/telemetry-impls/load-then-clone/action.yml
+++ b/telemetry-impls/load-then-clone/action.yml
@@ -28,7 +28,9 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.GH_TOKEN }}
       run: |
-        echo "artifact_not_found=$(gh api repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts --jq '.artifacts[] | select(.name=="telemetry-tools-env-vars")' | grep -q . && echo '0' || echo '1')" >> $GITHUB_OUTPUT;
+        artifact_not_found=$(gh api repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts --jq '.artifacts[] | select(.name=="telemetry-tools-env-vars")' | grep -q . && echo '0' || echo '1');
+        echo "artifact_not_found=${artifact_not_found}" >> $GITHUB_OUTPUT;
+        echo "artifact_not_found=${artifact_not_found}"
     - name: Download base environment variables file
       uses: actions/download-artifact@v4
       if: steps.check-artifact-exists.outputs.artifact_not_found == '1'

--- a/telemetry-impls/load-then-clone/action.yml
+++ b/telemetry-impls/load-then-clone/action.yml
@@ -19,6 +19,10 @@ inputs:
     required: true
     description: "GitHub token to use to check for artifact"
 
+outputs:
+  artifact_found:
+    description: "Whether the artifact was found"
+    value: ${{ steps.check-artifact-exists.outputs.artifact_found }}
 runs:
   using: 'composite'
   steps:

--- a/telemetry-impls/load-then-clone/action.yml
+++ b/telemetry-impls/load-then-clone/action.yml
@@ -14,11 +14,6 @@ description: |
   As a result, we clone the code twice: first to learn how to load the variables,
   then another time when the variables are actually set.
 
-inputs:
-  GH_TOKEN:
-    required: true
-    description: "GitHub token to use to check for artifact"
-
 outputs:
   artifact_found:
     description: "Whether the artifact was found"
@@ -29,10 +24,10 @@ runs:
     - name: Check if artifact exists
       id: check-artifact-exists
       shell: bash
-      env:
-        GH_TOKEN: ${{ inputs.GH_TOKEN }}
       run: |
-        artifact_found=$(gh api repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts --jq '.artifacts[] | select(.name=="telemetry-tools-env-vars")' | grep -q . && echo 'true' || echo 'false');
+        artifact_found=$(gh api repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts \
+          --jq '.artifacts[] | select(.name=="telemetry-tools-env-vars")' \
+          | grep -q . && echo 'true' || echo 'false');
         echo "artifact_found=${artifact_found}" | tee -a $GITHUB_OUTPUT;
     - name: Download base environment variables file
       uses: actions/download-artifact@v4

--- a/telemetry-impls/load-then-clone/action.yml
+++ b/telemetry-impls/load-then-clone/action.yml
@@ -31,15 +31,20 @@ runs:
       #      in other words, expand to find the variable name, then dereference that variable name
       # The goofy env_var_value filtering through tr is to ensure that the strings don't include quotes.
       run: |
-        while read LINE; do
-          env_var_name="$( cut -d '=' -f 1 <<< "$LINE" )";
-          if [ "${!env_var_name}" = "" ]; then
-            env_var_value="$(echo ${LINE#*=} | tr -d '"')"
-            echo "${env_var_name}=$(echo "${env_var_value}" | sed 's/^,//')" >> ${GITHUB_ENV};
-          else
-            echo "Load base env info: ignoring new value for "${env_var_name}" in loading base env vars. It is already set to "${!env_var_name}"." >&2;
-          fi
-        done <telemetry-artifacts/telemetry-env-vars
+        gh api repos/rapidsai/cuml/actions/runs/${GITHUB_RUN_ID}/artifacts --jq '.artifacts[] | select(.name=="telemetry-tools-env-vars")' | grep -q .;
+        if [ $? -eq 0 ]; then
+          while read LINE; do
+            env_var_name="$( cut -d '=' -f 1 <<< "$LINE" )";
+            if [ "${!env_var_name}" = "" ]; then
+              env_var_value="$(echo ${LINE#*=} | tr -d '"')"
+              echo "${env_var_name}=$(echo "${env_var_value}" | sed 's/^,//')" >> ${GITHUB_ENV};
+            else
+              echo "Load base env info: ignoring new value for "${env_var_name}" in loading base env vars. It is already set to "${!env_var_name}"." >&2;
+            fi
+          done <telemetry-artifacts/telemetry-env-vars
+        else
+          echo "Load base env info: no telemetry-tools-env-vars artifact found - using default values" >&2;
+        fi
     - name: Clone shared-actions repo with loaded env vars
       uses: actions/checkout@v4
       with:

--- a/telemetry-impls/load-then-clone/action.yml
+++ b/telemetry-impls/load-then-clone/action.yml
@@ -19,6 +19,7 @@ runs:
   steps:
     - name: Check if artifact exists
       id: check-artifact-exists
+      shell: bash
       run: |
         gh api repos/rapidsai/cuml/actions/runs/${GITHUB_RUN_ID}/artifacts --jq '.artifacts[] | select(.name=="telemetry-tools-env-vars")' | grep -q .;
         echo "artifact_not_found=$?" >> $GITHUB_OUTPUT

--- a/telemetry-impls/stash-base-env-vars/action.yml
+++ b/telemetry-impls/stash-base-env-vars/action.yml
@@ -18,7 +18,6 @@ runs:
     - name: Write base env vars to a file
       shell: bash
       run: |
-        TRACEPARENT=$(./shared-actions/telemetry-impls/traceparent.sh "${OTEL_SERVICE_NAME}")
         OTEL_RESOURCE_ATTRIBUTES="${OTEL_RESOURCE_ATTRIBUTES},git.repository=${GITHUB_REPOSITORY}"
         OTEL_RESOURCE_ATTRIBUTES="${OTEL_RESOURCE_ATTRIBUTES},git.ref=${GITHUB_REF}"
         OTEL_RESOURCE_ATTRIBUTES="${OTEL_RESOURCE_ATTRIBUTES},git.sha=${GITHUB_SHA}"
@@ -28,11 +27,8 @@ runs:
         OTEL_TRACES_EXPORTER=${OTEL_TRACES_EXPORTER:-otlp}
         OTEL_EXPORTER_OTLP_PROTOCOL=${OTEL_EXPORTER_OTLP_PROTOCOL:-grpc}
         OTEL_RESOURCE_ATTRIBUTES="$(echo "${OTEL_RESOURCE_ATTRIBUTES}" | sed 's/^,//')"
-        OTEL_SERVICE_NAME="${OTEL_SERVICE_NAME}"
         SHARED_ACTIONS_REPO=${SHARED_ACTIONS_REPO:-rapidsai/shared-actions}
         SHARED_ACTIONS_REF=${SHARED_ACTIONS_REF:-main}
-        START_TIME="${START_TIME:-$(date +'%s')}"
-        TRACEPARENT="${TRACEPARENT}"
         EOF
     - name: Upload env vars file
       uses: actions/upload-artifact@v4

--- a/telemetry-impls/summarize/action.yml
+++ b/telemetry-impls/summarize/action.yml
@@ -35,6 +35,13 @@ runs:
     - name: Run parse and send trace/spans to endpoint
       shell: bash
       run: |
+        OTEL_SERVICE_NAME=${OTEL_SERVICE_NAME:-${GITHUB_WORKFLOW}-${GITHUB_REPOSITORY#*/}}
+        export OTEL_SERVICE_NAME
+        echo "OTEL_SERVICE_NAME=${OTEL_SERVICE_NAME}" >> $GITHUB_ENV
+        TRACEPARENT=$(./shared-actions/telemetry-impls/traceparent.sh "${OTEL_SERVICE_NAME}")
+        export TRACEPARENT
+        echo "TRACEPARENT=${TRACEPARENT}" >> $GITHUB_ENV
+
         ls -lR telemetry-artifacts
         timeout 5m python3 ./shared-actions/telemetry-impls/summarize/send_trace.py
     - name: Clean up attributes artifacts from all jobs

--- a/telemetry-impls/summarize/send_trace.py
+++ b/telemetry-impls/summarize/send_trace.py
@@ -371,8 +371,8 @@ def main() -> None:
             env_vars = os.environ
     global_attrs = {k: v for k, v in attributes.items() if k.startswith("git.")}
     try:
-        global_attrs["service.name"] = os.getenv("OTEL_SERVICE_NAME", env_vars.get("OTEL_SERVICE_NAME"))
-        trace_id = int(os.getenv("TRACEPARENT", env_vars.get("TRACEPARENT")).split("-")[1], 16)
+        global_attrs["service.name"] = os.getenv("OTEL_SERVICE_NAME", env_vars["OTEL_SERVICE_NAME"])
+        trace_id = int(os.getenv("TRACEPARENT", env_vars["TRACEPARENT"]).split("-")[1], 16)
     except KeyError:
         logging.error("OTEL_SERVICE_NAME and/or TRACEPARENT not found in environment or attribute files")
         sys.exit(1)

--- a/telemetry-impls/summarize/send_trace.py
+++ b/telemetry-impls/summarize/send_trace.py
@@ -379,7 +379,7 @@ def main() -> None:
 
     provider = TracerProvider(
         resource=Resource(global_attrs),
-        id_generator=RapidsSpanIdGenerator(trace_id=trace_id, job_name=os.environ["OTEL_SERVICE_NAME"]),
+        id_generator=RapidsSpanIdGenerator(trace_id=trace_id, job_name=global_attrs["service.name"]),
     )
     provider.add_span_processor(span_processor=SpanProcessor(OTLPSpanExporter()))
     tracer = trace.get_tracer("GitHub Actions parser", "0.0.1", tracer_provider=provider)


### PR DESCRIPTION
This is an alternative approach to #55 suggested by @trxcllnt and @bdice. I also moved the setting of two top-level env vars further into the process, so that we can more easily set a default OTEL_SERVICE_NAME and not require that to be set in top-level workflows.

Tests run:
* Happy path: 
  * [x] [Set shared-actions branch info in ucxx pr.yaml](https://github.com/rapidsai/ucxx/actions/runs/15468661744?pr=431). 
  * [x] [Verify that telemetry-env-vars file is found by later steps](https://github.com/rapidsai/ucxx/actions/runs/15468661744/job/43547340506?pr=431#step:3:24). 
  * [x] Verify that [branch specified by pr.yaml matches branch checked out in [shared-workflow call](https://github.com/rapidsai/ucxx/actions/runs/15468661744/job/43546988073?pr=431#step:8:177) and in [later summarize shared-actions call](https://github.com/rapidsai/ucxx/actions/runs/15468661744/job/43547340506?pr=431#step:3:123)
* re-run: With the shared-workflow call intentionally erroring, re-run the workflow, selecting to re-run only failed steps
  * [x] Verify that the telemetry steps for re-run jobs are skipped. 

![telemetry-setup-skipped](https://github.com/user-attachments/assets/13a4c47b-d26a-4c06-aa34-915e6ce2d478)

  * [x] Verify that no download of telemetry-env-vars error messages [appear in the run summary](https://github.com/rapidsai/ucxx/actions/runs/15470966177?pr=431)
* unconfigured jobs: 
  * [x] should not show download errors in summary. 
  * [x] No telemetry intermediary files should be present in the job summary: https://github.com/rapidsai/ucxx/actions/runs/15473731439