### PR TITLE
Allow main branch for nightly CI checks

### DIFF
--- a/check_nightly_success/check-nightly-success/check.py
+++ b/check_nightly_success/check-nightly-success/check.py
@@ -71,9 +71,9 @@ def main(
         branch_dict[run["head_branch"]].append(run)
 
     for branch, branch_runs in branch_dict.items():
-        # only consider RAPIDS release branches, which have versions like
-        # '25.02' (RAPIDS) or '0.42' (ucxx, ucx-py)
-        if not re.match("branch-[0-9]{1,2}.[0-9]{2}", branch):
+        # Only consider RAPIDS development branches, which are named 'main' or
+        # have versions like '25.02' (RAPIDS CalVer) or '0.42' (ucxx, ucx-py)
+        if branch != "main" or re.match("branch-[0-9]{1,2}.[0-9]{2}", branch):
             continue
 
         latest_success[branch] = None


### PR DESCRIPTION
This allows `main` branches to be used for nightly CI checks. This is needed to unblock RMM because of its change to the new RAPIDS branching strategy (https://docs.rapids.ai/notices/rsn0047/).
