### PR TITLE
add prepare conda action to achieve lock within PR

### DIFF
--- a/prepare-conda-env/action.yml
+++ b/prepare-conda-env/action.yml
@@ -86,19 +86,22 @@ runs:
       run: |
         import yaml
         import os
+        from pprint import pprint
         with open("${{ steps.lockfile-filename.outputs.filename }}", 'r') as f:
           lockfile = yaml.safe_load(f)
-        local_file_pkg_names = {pkg.rsplit('-', 2)[0] for _, _, pkg in os.walk("${{ env.RAPIDS_UNZIP_DIR }}") if pkg.endswith('.conda')}
+        local_file_pkg_names = {pkg.rsplit('-', 2)[0] for _, _, pkg in os.walk("downloaded-packages") if pkg.endswith('.conda')}
         print(local_file_pkg_names)
         edited_dependencies = []
         for pkg in lockfile['dependencies']:
+          print(pkg)
           if isinstance(pkg, str):
             pkg_name = pkg.split('=', 1)[0]
             if pkg_name in local_file_pkg_names:
-              edited_dependencies.append(f'{pkg_name}')
+              edited_dependencies.append(pkg_name)
               continue
           edited_dependencies.append(pkg)
         lockfile['dependencies'] = edited_dependencies
+        pprint(lockfile)
         with open("${{ steps.lockfile-filename.outputs.filename }}", 'w') as f:
           yaml.dump(lockfile, f)
     - name: archive lockfile for reference

--- a/prepare-conda-env/action.yml
+++ b/prepare-conda-env/action.yml
@@ -57,6 +57,7 @@ runs:
         export RAPIDS_UNZIP_DIR="$(pwd)/downloaded-packages"
         mkdir -p $RAPIDS_UNZIP_DIR
         CPP_CHANNEL=$(rapids-download-conda-from-github ${{ inputs.dependency-key }})
+        ls -lRa $RAPIDS_UNZIP_DIR
 
         if [ ! -f "${{ steps.lockfile-filename.outputs.filename }}" ] || [ "${{ inputs.relock }}" == "true" ]; then
           mamba install -c conda-forge conda-lock
@@ -73,12 +74,28 @@ runs:
 
           CONDA_ARCH="linux-$([ ${{ inputs.arch }} = 'amd64' ] && echo '64' || echo 'aarch64' )"
 
-          conda-lock -f "${ENV_YAML_DIR}/env.yaml" --kind env -p $CONDA_ARCH 
+          conda-lock -f "${ENV_YAML_DIR}/env.yaml" --kind env -p $CONDA_ARCH
+
           mv conda-${CONDA_ARCH}.lock.yml ${{ steps.lockfile-filename.outputs.filename }}
         else
           rapids-logger "Skipping conda-lock as it already exists and relock is not true"
         fi
 
+    # - name: Unpin local file dependencies in lockfile
+    #   shell: python
+    #   run: |
+    #     import yaml
+    #     with open(${{ steps.lockfile-filename.outputs.filename }}, 'r') as f:
+    #       lockfile = yaml.safe_load(f)
+    #     local_file_pkgs = (pkg.split() for pkg in os.listdir(RAPIDS_UNZIP_DIR))
+    #     edited_dependencies = []
+    #     for pkg in lockfile['dependencies']:
+          
+    #         pkg['file:'] = 'file:*'
+    #         edited_dependencies.append(pkg)
+    #     lockfile['dependencies'] = edited_dependencies
+    #     with open(${{ steps.lockfile-filename.outputs.filename }}, 'w') as f:
+    #       yaml.dump(lockfile, f)
     - name: archive lockfile for reference
       uses: actions/upload-artifact@v4
       with:

--- a/prepare-conda-env/action.yml
+++ b/prepare-conda-env/action.yml
@@ -69,7 +69,9 @@ runs:
             --prepend-channel "${CPP_CHANNEL}" \
             --matrix "cuda=${CUDA_VERSION%.*};arch=${{ inputs.arch }}" | tee "${ENV_YAML_DIR}/env.yaml"
 
-          conda-lock -f "${ENV_YAML_DIR}/env.yaml" --kind env --lockfile ${{ steps.lockfile-filename.outputs.filename }} -p linux-${{ inputs.arch == 'amd64' ? '64' : 'aarch64' }}
+          CONDA_ARCH="linux-$([ ${{ inputs.arch }} = 'amd64' ] && echo '64' || echo 'aarch64' )"
+
+          conda-lock -f "${ENV_YAML_DIR}/env.yaml" --kind env --lockfile ${{ steps.lockfile-filename.outputs.filename }} -p $CONDA_ARCH
         else
           rapids-logger "Skipping conda-lock as it already exists and relock is not true"
         fi

--- a/prepare-conda-env/action.yml
+++ b/prepare-conda-env/action.yml
@@ -71,7 +71,8 @@ runs:
 
           CONDA_ARCH="linux-$([ ${{ inputs.arch }} = 'amd64' ] && echo '64' || echo 'aarch64' )"
 
-          conda-lock -f "${ENV_YAML_DIR}/env.yaml" --kind env --lockfile ${{ steps.lockfile-filename.outputs.filename }} -p $CONDA_ARCH
+          conda-lock -f "${ENV_YAML_DIR}/env.yaml" --kind env -p $CONDA_ARCH 
+          mv conda-${CONDA_ARCH}.lock.yml ${{ steps.lockfile-filename.outputs.filename }}
         else
           rapids-logger "Skipping conda-lock as it already exists and relock is not true"
         fi

--- a/prepare-conda-env/action.yml
+++ b/prepare-conda-env/action.yml
@@ -86,6 +86,7 @@ runs:
       run: |
         import yaml
         import os
+        import re
         from pprint import pprint
         with open("${{ steps.lockfile-filename.outputs.filename }}", 'r') as f:
           lockfile = yaml.safe_load(f)

--- a/prepare-conda-env/action.yml
+++ b/prepare-conda-env/action.yml
@@ -81,21 +81,25 @@ runs:
           rapids-logger "Skipping conda-lock as it already exists and relock is not true"
         fi
 
-    # - name: Unpin local file dependencies in lockfile
-    #   shell: python
-    #   run: |
-    #     import yaml
-    #     with open(${{ steps.lockfile-filename.outputs.filename }}, 'r') as f:
-    #       lockfile = yaml.safe_load(f)
-    #     local_file_pkgs = (pkg.split() for pkg in os.listdir(RAPIDS_UNZIP_DIR))
-    #     edited_dependencies = []
-    #     for pkg in lockfile['dependencies']:
-          
-    #         pkg['file:'] = 'file:*'
-    #         edited_dependencies.append(pkg)
-    #     lockfile['dependencies'] = edited_dependencies
-    #     with open(${{ steps.lockfile-filename.outputs.filename }}, 'w') as f:
-    #       yaml.dump(lockfile, f)
+    - name: Unpin local file dependencies in lockfile
+      shell: python
+      run: |
+        import yaml
+        with open(${{ steps.lockfile-filename.outputs.filename }}, 'r') as f:
+          lockfile = yaml.safe_load(f)
+        local_file_pkg_names = {pkg.rsplit('-', 2)[0] for _, _, pkg in os.walk(RAPIDS_UNZIP_DIR) if pkg.endswith('.conda')}
+        print(local_file_pkg_names)
+        edited_dependencies = []
+        for pkg in lockfile['dependencies']:
+          if isinstance(pkg, str):
+            pkg_name = pkg.split('=', 1)[0]
+            if pkg_name in local_file_pkg_names:
+              edited_dependencies.append(f'{pkg_name}')
+              continue
+          edited_dependencies.append(pkg)
+        lockfile['dependencies'] = edited_dependencies
+        with open(${{ steps.lockfile-filename.outputs.filename }}, 'w') as f:
+          yaml.dump(lockfile, f)
     - name: archive lockfile for reference
       uses: actions/upload-artifact@v4
       with:

--- a/prepare-conda-env/action.yml
+++ b/prepare-conda-env/action.yml
@@ -51,9 +51,10 @@ runs:
       shell: bash
       run: |
         set -Eeuxo pipefail
-        if [ ! -f "${{ steps.lockfile-filename.outputs.filename }}" ] || [ "${{ inputs.relock }}" == "true" ]; then
-          CPP_CHANNEL=$(rapids-download-conda-from-github ${{ inputs.dependency-key }})
 
+        CPP_CHANNEL=$(rapids-download-conda-from-github ${{ inputs.dependency-key }})
+
+        if [ ! -f "${{ steps.lockfile-filename.outputs.filename }}" ] || [ "${{ inputs.relock }}" == "true" ]; then
           rapids-logger "Generate ${inputs.dependency-key} testing dependencies"
 
           ENV_YAML_DIR="$(mktemp -d)"

--- a/prepare-conda-env/action.yml
+++ b/prepare-conda-env/action.yml
@@ -46,7 +46,7 @@ runs:
     - name: Run conda-lock if needed
       shell: bash
       run: |
-        if [ -f "${{ steps.lockfile-filename.outputs.filename }}" ] || [ "${{ inputs.relock }}" == "true" ]; then
+        if [ ! -f "${{ steps.lockfile-filename.outputs.filename }}" ] || [ "${{ inputs.relock }}" == "true" ]; then
           CPP_CHANNEL=$(rapids-download-conda-from-github ${{ inputs.dependency-key }})
 
           rapids-logger "Generate ${inputs.dependency-key} testing dependencies"

--- a/prepare-conda-env/action.yml
+++ b/prepare-conda-env/action.yml
@@ -69,6 +69,12 @@ runs:
           rapids-logger "Skipping conda-lock as it already exists and relock is not true"
         fi
 
+    - name: archive lockfile for reference
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ steps.lockfile-filename.outputs.filename }}
+        path: ${{ steps.lockfile-filename.outputs.filename }}
+
     - name: Create environment
       shell: bash
       run: |

--- a/prepare-conda-env/action.yml
+++ b/prepare-conda-env/action.yml
@@ -89,7 +89,7 @@ runs:
         from pprint import pprint
         with open("${{ steps.lockfile-filename.outputs.filename }}", 'r') as f:
           lockfile = yaml.safe_load(f)
-        local_file_pkg_names = {pkg.rsplit('-', 2)[0] for _, _, pkg_list in os.walk("downloaded-packages") for pkg in pkg_list if pkg.endswith('.conda')}
+        local_file_pkg_names = {pkg.rsplit('-', 2)[0]: pkg.rsplit('-', 2)[1] for _, _, pkg_list in os.walk("downloaded-packages") for pkg in pkg_list if pkg.endswith('.conda')}
         print(local_file_pkg_names)
         edited_dependencies = []
         for pkg in lockfile['dependencies']:
@@ -97,7 +97,7 @@ runs:
           if isinstance(pkg, str):
             pkg_name = pkg.split('=', 1)[0]
             if pkg_name in local_file_pkg_names:
-              edited_dependencies.append(pkg_name)
+              edited_dependencies.append(f'{pkg_name}={local_file_pkg_names[pkg_name]}')
               continue
           edited_dependencies.append(pkg)
         lockfile['dependencies'] = edited_dependencies

--- a/prepare-conda-env/action.yml
+++ b/prepare-conda-env/action.yml
@@ -93,7 +93,7 @@ runs:
         local_file_pkg_names = {pkg.rsplit('-', 2)[0]: pkg.rsplit('-', 2)[1] for _, _, pkg_list in os.walk("downloaded-packages") for pkg in pkg_list if pkg.endswith('.conda')}
         print(local_file_pkg_names)
         edited_dependencies = []
-        alpha_package_regex = re.compile(r'(.+?)\.a\d+$')
+        alpha_package_regex = re.compile(r'(.+?)a\d+$')
         for pkg in lockfile['dependencies']:
           print(pkg)
           if isinstance(pkg, str):

--- a/prepare-conda-env/action.yml
+++ b/prepare-conda-env/action.yml
@@ -59,12 +59,13 @@ runs:
           rapids-logger "Generate ${{ inputs.dependency-key }} testing dependencies"
 
           ENV_YAML_DIR="$(mktemp -d)"
+          CUDA_VERSION=${{ inputs.cuda-version }}
 
           rapids-dependency-file-generator \
             --output conda \
             --file-key test_${{ inputs.dependency-key }} \
             --prepend-channel "${CPP_CHANNEL}" \
-            --matrix "cuda=${${{ inputs.cuda-version }}%.*};arch=${{ inputs.arch }}" | tee "${ENV_YAML_DIR}/env.yaml"
+            --matrix "cuda=${CUDA_VERSION%.*};arch=${{ inputs.arch }}" | tee "${ENV_YAML_DIR}/env.yaml"
 
           mamba env create --file "${ENV_YAML_DIR}/env.yaml" --dry-run --quiet | tee ${{ steps.lockfile-filename.outputs.filename }}
         else

--- a/prepare-conda-env/action.yml
+++ b/prepare-conda-env/action.yml
@@ -20,11 +20,7 @@ inputs:
     default: false
     description: |
       Whether to force a relock of the environment.
-  pr-number:
-    required: true
-    type: string
-    description: |
-      The pull request number to use for the cache key.
+
 outputs:
   env-path:
     description: |
@@ -40,19 +36,24 @@ runs:
       run: |
         echo "filename=.conda-lock-${{ inputs.dependency-key }}-${{ inputs.cuda-version }}-${{ inputs.arch }}.yml" >> $GITHUB_OUTPUT
 
+    - name: Get PR number
+      id: pr-number
+      shell: bash
+      run: |
+        echo "pr-number=$(echo ${GITHUB_REF_NAME} | sed 's/.*\///')" >> $GITHUB_OUTPUT
+
     - name: Retrieve any existing lockfile
       uses: actions/cache@v4
       with:
-        key: conda-lockfile-${{ inputs.dependency-key }}-${{ inputs.cuda-version }}-${{ inputs.arch }}-${{ inputs.pr-number }}
+        key: conda-lockfile-${{ inputs.dependency-key }}-${{ inputs.cuda-version }}-${{ inputs.arch }}-${{ steps.pr-number.outputs.pr-number }}
         path: ${{ steps.lockfile-filename.outputs.filename }}
         restore-keys: |
-          conda-lockfile-${{ inputs.dependency-key }}-${{ inputs.cuda-version }}-${{ inputs.arch }}-${{ inputs.pr-number }}
+          conda-lockfile-${{ inputs.dependency-key }}-${{ inputs.cuda-version }}-${{ inputs.arch }}-${{ steps.pr-number.outputs.pr-number }}
 
     - name: Run conda-lock if needed
       shell: bash
       run: |
         set -Eeuxo pipefail
-
         CPP_CHANNEL=$(rapids-download-conda-from-github ${{ inputs.dependency-key }})
 
         if [ ! -f "${{ steps.lockfile-filename.outputs.filename }}" ] || [ "${{ inputs.relock }}" == "true" ]; then

--- a/prepare-conda-env/action.yml
+++ b/prepare-conda-env/action.yml
@@ -54,6 +54,8 @@ runs:
       shell: bash
       run: |
         set -Eeuxo pipefail
+        export RAPIDS_UNZIP_DIR="$(pwd)/downloaded-packages"
+        mkdir -p $RAPIDS_UNZIP_DIR
         CPP_CHANNEL=$(rapids-download-conda-from-github ${{ inputs.dependency-key }})
 
         if [ ! -f "${{ steps.lockfile-filename.outputs.filename }}" ] || [ "${{ inputs.relock }}" == "true" ]; then

--- a/prepare-conda-env/action.yml
+++ b/prepare-conda-env/action.yml
@@ -16,7 +16,7 @@ inputs:
     description: |
       The CUDA version to build for, such as 11.7, 12.1, etc.
   relock:
-    type: boolean
+    type: string
     default: false
     description: |
       Whether to force a relock of the environment.
@@ -67,7 +67,7 @@ runs:
             --prepend-channel "${CPP_CHANNEL}" \
             --matrix "cuda=${CUDA_VERSION%.*};arch=${{ inputs.arch }}" | tee "${ENV_YAML_DIR}/env.yaml"
 
-          mamba env create --file "${ENV_YAML_DIR}/env.yaml" --dry-run --quiet | tee ${{ steps.lockfile-filename.outputs.filename }}
+          mamba env create --file "${ENV_YAML_DIR}/env.yaml" --dry-run | tee ${{ steps.lockfile-filename.outputs.filename }}
         else
           rapids-logger "Skipping conda-lock as it already exists and relock is not true"
         fi

--- a/prepare-conda-env/action.yml
+++ b/prepare-conda-env/action.yml
@@ -64,7 +64,7 @@ runs:
             --output conda \
             --file-key test_${{ inputs.dependency-key }} \
             --prepend-channel "${CPP_CHANNEL}" \
-            --matrix "cuda=${${{ inputs.cuda-version }}%.*};arch=${inputs.arch}" | tee "${ENV_YAML_DIR}/env.yaml"
+            --matrix "cuda=${${{ inputs.cuda-version }}%.*};arch=${{ inputs.arch }}" | tee "${ENV_YAML_DIR}/env.yaml"
 
           mamba env create --file "${ENV_YAML_DIR}/env.yaml" --dry-run --quiet | tee ${{ steps.lockfile-filename.outputs.filename }}
         else

--- a/prepare-conda-env/action.yml
+++ b/prepare-conda-env/action.yml
@@ -45,21 +45,22 @@ runs:
 
     - name: Run conda-lock if needed
       shell: bash
-      if: !isfile(steps.lockfile-filename.outputs.filename) || inputs.relock == true
       run: |
-        CPP_CHANNEL=$(rapids-download-conda-from-github ${{ inputs.dependency-key }})
+        if [ -f "${{ steps.lockfile-filename.outputs.filename }}" ] || [ "${{ inputs.relock }}" == "true" ]; then
+          CPP_CHANNEL=$(rapids-download-conda-from-github ${{ inputs.dependency-key }})
 
-        rapids-logger "Generate ${inputs.dependency-key} testing dependencies"
+          rapids-logger "Generate ${inputs.dependency-key} testing dependencies"
 
-        ENV_YAML_DIR="$(mktemp -d)"
+          ENV_YAML_DIR="$(mktemp -d)"
 
-        rapids-dependency-file-generator \
-          --output conda \
-          --file-key test_${{ inputs.dependency-key }} \
-          --prepend-channel "${CPP_CHANNEL}" \
-          --matrix "cuda=${${{ inputs.cuda-version }}%.*};arch=${inputs.arch}" | tee "${ENV_YAML_DIR}/env.yaml"
+          rapids-dependency-file-generator \
+            --output conda \
+            --file-key test_${{ inputs.dependency-key }} \
+            --prepend-channel "${CPP_CHANNEL}" \
+            --matrix "cuda=${${{ inputs.cuda-version }}%.*};arch=${inputs.arch}" | tee "${ENV_YAML_DIR}/env.yaml"
 
-        mamba env create --file "${ENV_YAML_DIR}/env.yaml" --dry-run --quiet | tee ${{ steps.lockfile-filename.outputs.filename }}
+          mamba env create --file "${ENV_YAML_DIR}/env.yaml" --dry-run --quiet | tee ${{ steps.lockfile-filename.outputs.filename }}
+        fi
 
     - name: Create environment
       shell: bash

--- a/prepare-conda-env/action.yml
+++ b/prepare-conda-env/action.yml
@@ -87,27 +87,27 @@ runs:
         import yaml
         import os
         import re
-        from pprint import pprint
         with open("${{ steps.lockfile-filename.outputs.filename }}", 'r') as f:
           lockfile = yaml.safe_load(f)
         local_file_pkg_names = {pkg.rsplit('-', 2)[0]: pkg.rsplit('-', 2)[1] for _, _, pkg_list in os.walk("downloaded-packages") for pkg in pkg_list if pkg.endswith('.conda')}
-        print(local_file_pkg_names)
         edited_dependencies = []
         alpha_package_regex = re.compile(r'(.+?)a\d+$')
         for pkg in lockfile['dependencies']:
-          print(pkg)
           if isinstance(pkg, str):
             pkg_name, version, build = pkg.split('=')
             if pkg_name in local_file_pkg_names:
+              # For local packages, we need to pick up the current local files. In other words, we need to replace
+              # the pins in the lockfile with pins for the current local files.
               edited_dependencies.append(f'{pkg_name}={local_file_pkg_names[pkg_name]}')
               continue
             elif alpha_package_regex.match(version):
+              # Exact pins to alpha packages will break depending on the contents of the nightly builds.
+              # We need to unpin the alpha package to the version without the alpha, which will allow the current nightly build to be used.
               version = alpha_package_regex.match(version).groups()[0]
               edited_dependencies.append(f'{pkg_name}={version}')
               continue
           edited_dependencies.append(pkg)
         lockfile['dependencies'] = edited_dependencies
-        pprint(lockfile)
         with open("${{ steps.lockfile-filename.outputs.filename }}", 'w') as f:
           yaml.dump(lockfile, f)
     - name: archive lockfile for reference

--- a/prepare-conda-env/action.yml
+++ b/prepare-conda-env/action.yml
@@ -45,7 +45,7 @@ runs:
 
     - name: Run conda-lock if needed
       shell: bash
-      if: ${{ !isfile(steps.lockfile-filename.outputs.filename) || inputs.relock == true }}
+      if: !isfile(steps.lockfile-filename.outputs.filename) || inputs.relock == true
       run: |
         CPP_CHANNEL=$(rapids-download-conda-from-github ${{ inputs.dependency-key }})
 

--- a/prepare-conda-env/action.yml
+++ b/prepare-conda-env/action.yml
@@ -1,0 +1,78 @@
+name: Create Locked Conda Environment
+inputs:
+  dependency-key:
+    required: true
+    type: string
+    description: |
+      The key of the dependency to generate, such as cpp, python, etc.
+  arch:
+    required: true
+    type: string
+    description: |
+      The architecture to build for, such as x86_64, aarch64, etc.
+  cuda-version:
+    required: true
+    type: string
+    description: |
+      The CUDA version to build for, such as 11.7, 12.1, etc.
+  relock:
+    type: boolean
+    default: false
+    description: |
+      Whether to force a relock of the environment.
+outputs:
+  env-path:
+    description: |
+      The path to the conda environment.
+    value: ${{ steps.create-env.outputs.env-path }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: compute lockfile filename
+      id: lockfile-filename
+      shell: bash
+      run: |
+        echo "filename=.conda-lock-${{ inputs.dependency-key }}-${{ inputs.cuda-version }}-${{ inputs.arch }}.yml" >> $GITHUB_OUTPUT
+
+    - name: Retrieve any existing lockfile
+      uses: actions/cache@v4
+      with:
+        key: conda-lockfile-${{ inputs.dependency-key }}-${{ inputs.cuda-version }}-${{ inputs.arch }}-${{ github.event.pull_request.number }}
+        path: ${{ steps.lockfile-filename.outputs.filename }}
+        restore-keys: |
+          conda-lockfile-${{ inputs.dependency-key }}-${{ inputs.cuda-version }}-${{ inputs.arch }}-${{ github.event.pull_request.number }}
+
+    - name: Run conda-lock if needed
+      shell: bash
+      if: ${{ !isfile(steps.lockfile-filename.outputs.filename) || inputs.relock == true }}
+      run: |
+        CPP_CHANNEL=$(rapids-download-conda-from-github ${{ inputs.dependency-key }})
+
+        rapids-logger "Generate ${inputs.dependency-key} testing dependencies"
+
+        ENV_YAML_DIR="$(mktemp -d)"
+
+        rapids-dependency-file-generator \
+          --output conda \
+          --file-key test_${{ inputs.dependency-key }} \
+          --prepend-channel "${CPP_CHANNEL}" \
+          --matrix "cuda=${${{ inputs.cuda-version }}%.*};arch=${inputs.arch}" | tee "${ENV_YAML_DIR}/env.yaml"
+
+        mamba env create --file "${ENV_YAML_DIR}/env.yaml" --dry-run --quiet | tee ${{ steps.lockfile-filename.outputs.filename }}
+
+    - name: Create environment
+      shell: bash
+      run: |
+        rapids-mamba-retry env create --yes -f ${{ steps.lockfile-filename.outputs.filename }} -n test
+
+        RESULTS_DIR=${RAPIDS_TESTS_DIR:-"$(mktemp -d)"}
+        RAPIDS_TESTS_DIR=${RAPIDS_TESTS_DIR:-"${RESULTS_DIR}/test-results"}/
+        mkdir -p "${RAPIDS_TESTS_DIR}"
+        echo "RESULTS_DIR=${RESULTS_DIR}" >> $GITHUB_ENV
+        echo "RAPIDS_TESTS_DIR=${RAPIDS_TESTS_DIR}" >> $GITHUB_ENV
+
+        rapids-print-env
+
+        rapids-logger "Check GPU usage"
+        nvidia-smi

--- a/prepare-conda-env/action.yml
+++ b/prepare-conda-env/action.yml
@@ -89,7 +89,7 @@ runs:
         from pprint import pprint
         with open("${{ steps.lockfile-filename.outputs.filename }}", 'r') as f:
           lockfile = yaml.safe_load(f)
-        local_file_pkg_names = {pkg.rsplit('-', 2)[0] for _, _, pkg in os.walk("downloaded-packages") if pkg.endswith('.conda')}
+        local_file_pkg_names = {pkg.rsplit('-', 2)[0] for _, _, pkg_list in os.walk("downloaded-packages") for pkg in pkg_list if pkg.endswith('.conda')}
         print(local_file_pkg_names)
         edited_dependencies = []
         for pkg in lockfile['dependencies']:

--- a/prepare-conda-env/action.yml
+++ b/prepare-conda-env/action.yml
@@ -92,12 +92,17 @@ runs:
         local_file_pkg_names = {pkg.rsplit('-', 2)[0]: pkg.rsplit('-', 2)[1] for _, _, pkg_list in os.walk("downloaded-packages") for pkg in pkg_list if pkg.endswith('.conda')}
         print(local_file_pkg_names)
         edited_dependencies = []
+        alpha_package_regex = re.compile(r'(.+?)\.a\d+$')
         for pkg in lockfile['dependencies']:
           print(pkg)
           if isinstance(pkg, str):
-            pkg_name = pkg.split('=', 1)[0]
+            pkg_name, version, build = pkg.split('=')
             if pkg_name in local_file_pkg_names:
               edited_dependencies.append(f'{pkg_name}={local_file_pkg_names[pkg_name]}')
+              continue
+            elif alpha_package_regex.match(version):
+              version = alpha_package_regex.match(version).groups()[0]
+              edited_dependencies.append(f'{pkg_name}={version}')
               continue
           edited_dependencies.append(pkg)
         lockfile['dependencies'] = edited_dependencies

--- a/prepare-conda-env/action.yml
+++ b/prepare-conda-env/action.yml
@@ -85,9 +85,10 @@ runs:
       shell: python
       run: |
         import yaml
-        with open(${{ steps.lockfile-filename.outputs.filename }}, 'r') as f:
+        import os
+        with open("${{ steps.lockfile-filename.outputs.filename }}", 'r') as f:
           lockfile = yaml.safe_load(f)
-        local_file_pkg_names = {pkg.rsplit('-', 2)[0] for _, _, pkg in os.walk(RAPIDS_UNZIP_DIR) if pkg.endswith('.conda')}
+        local_file_pkg_names = {pkg.rsplit('-', 2)[0] for _, _, pkg in os.walk("${{ env.RAPIDS_UNZIP_DIR }}") if pkg.endswith('.conda')}
         print(local_file_pkg_names)
         edited_dependencies = []
         for pkg in lockfile['dependencies']:
@@ -98,7 +99,7 @@ runs:
               continue
           edited_dependencies.append(pkg)
         lockfile['dependencies'] = edited_dependencies
-        with open(${{ steps.lockfile-filename.outputs.filename }}, 'w') as f:
+        with open("${{ steps.lockfile-filename.outputs.filename }}", 'w') as f:
           yaml.dump(lockfile, f)
     - name: archive lockfile for reference
       uses: actions/upload-artifact@v4

--- a/prepare-conda-env/action.yml
+++ b/prepare-conda-env/action.yml
@@ -21,6 +21,7 @@ inputs:
     description: |
       Whether to force a relock of the environment.
   pr-number:
+    required: true
     type: string
     description: |
       The pull request number to use for the cache key.
@@ -55,7 +56,7 @@ runs:
         CPP_CHANNEL=$(rapids-download-conda-from-github ${{ inputs.dependency-key }})
 
         if [ ! -f "${{ steps.lockfile-filename.outputs.filename }}" ] || [ "${{ inputs.relock }}" == "true" ]; then
-          rapids-logger "Generate ${inputs.dependency-key} testing dependencies"
+          rapids-logger "Generate ${{ inputs.dependency-key }} testing dependencies"
 
           ENV_YAML_DIR="$(mktemp -d)"
 

--- a/prepare-conda-env/action.yml
+++ b/prepare-conda-env/action.yml
@@ -20,6 +20,10 @@ inputs:
     default: false
     description: |
       Whether to force a relock of the environment.
+  pr-number:
+    type: string
+    description: |
+      The pull request number to use for the cache key.
 outputs:
   env-path:
     description: |
@@ -38,10 +42,10 @@ runs:
     - name: Retrieve any existing lockfile
       uses: actions/cache@v4
       with:
-        key: conda-lockfile-${{ inputs.dependency-key }}-${{ inputs.cuda-version }}-${{ inputs.arch }}-${{ github.event.pull_request.number }}
+        key: conda-lockfile-${{ inputs.dependency-key }}-${{ inputs.cuda-version }}-${{ inputs.arch }}-${{ inputs.pr-number }}
         path: ${{ steps.lockfile-filename.outputs.filename }}
         restore-keys: |
-          conda-lockfile-${{ inputs.dependency-key }}-${{ inputs.cuda-version }}-${{ inputs.arch }}-${{ github.event.pull_request.number }}
+          conda-lockfile-${{ inputs.dependency-key }}-${{ inputs.cuda-version }}-${{ inputs.arch }}-${{ inputs.pr-number }}
 
     - name: Run conda-lock if needed
       shell: bash

--- a/prepare-conda-env/action.yml
+++ b/prepare-conda-env/action.yml
@@ -46,6 +46,7 @@ runs:
     - name: Run conda-lock if needed
       shell: bash
       run: |
+        set -Eeuxo pipefail
         if [ ! -f "${{ steps.lockfile-filename.outputs.filename }}" ] || [ "${{ inputs.relock }}" == "true" ]; then
           CPP_CHANNEL=$(rapids-download-conda-from-github ${{ inputs.dependency-key }})
 
@@ -60,6 +61,8 @@ runs:
             --matrix "cuda=${${{ inputs.cuda-version }}%.*};arch=${inputs.arch}" | tee "${ENV_YAML_DIR}/env.yaml"
 
           mamba env create --file "${ENV_YAML_DIR}/env.yaml" --dry-run --quiet | tee ${{ steps.lockfile-filename.outputs.filename }}
+        else
+          rapids-logger "Skipping conda-lock as it already exists and relock is not true"
         fi
 
     - name: Create environment

--- a/prepare-conda-env/action.yml
+++ b/prepare-conda-env/action.yml
@@ -34,7 +34,7 @@ runs:
       id: lockfile-filename
       shell: bash
       run: |
-        echo "filename=.conda-lock-${{ inputs.dependency-key }}-${{ inputs.cuda-version }}-${{ inputs.arch }}.yml" >> $GITHUB_OUTPUT
+        echo "filename=conda-lock-${{ inputs.dependency-key }}-${{ inputs.cuda-version }}-${{ inputs.arch }}.yml" >> $GITHUB_OUTPUT
 
     - name: Get PR number
       id: pr-number
@@ -57,6 +57,7 @@ runs:
         CPP_CHANNEL=$(rapids-download-conda-from-github ${{ inputs.dependency-key }})
 
         if [ ! -f "${{ steps.lockfile-filename.outputs.filename }}" ] || [ "${{ inputs.relock }}" == "true" ]; then
+          mamba install -c conda-forge conda-lock
           rapids-logger "Generate ${{ inputs.dependency-key }} testing dependencies"
 
           ENV_YAML_DIR="$(mktemp -d)"
@@ -68,7 +69,7 @@ runs:
             --prepend-channel "${CPP_CHANNEL}" \
             --matrix "cuda=${CUDA_VERSION%.*};arch=${{ inputs.arch }}" | tee "${ENV_YAML_DIR}/env.yaml"
 
-          mamba env create --file "${ENV_YAML_DIR}/env.yaml" --dry-run | tee ${{ steps.lockfile-filename.outputs.filename }}
+          conda-lock -f "${ENV_YAML_DIR}/env.yaml" --kind env --lockfile ${{ steps.lockfile-filename.outputs.filename }} -p linux-${{ inputs.arch == 'amd64' ? '64' : 'aarch64' }}
         else
           rapids-logger "Skipping conda-lock as it already exists and relock is not true"
         fi


### PR DESCRIPTION
The goal here is to cache and reuse a frozen environment for test dependencies within the scope of one PR. If it works for Conda, it'll be easy to extend to pip stuff too.

The idea here is to extract the environment creation code out of each project's test setup scripts (e.g. [cudf cpp](https://github.com/rapidsai/cudf/blob/branch-25.08/ci/test_cpp_common.sh#L8-L21), and to tie that to a github actions cache that is specific to a PR. This file should never be checked in to the source tree. It only ever exists in the github actions cache.

Supersedes #61 - uses a different branch name without a slash in it.