### PR TITLE
fix: don't consider latest branch if it has no runs

### DIFF
--- a/check_nightly_success/check-nightly-success/check.py
+++ b/check_nightly_success/check-nightly-success/check.py
@@ -71,8 +71,8 @@ def main(
         branch_dict[run["head_branch"]].append(run)
 
     for branch, branch_runs in branch_dict.items():
-        # only consider RAPIDS release branches, which have versions like
-        # '25.02' (RAPIDS) or '0.42' (ucxx, ucx-py)
+        # Only consider RAPIDS release branches, which have versions like
+        # '25.02' (RAPIDS) or '0.42' (ucxx, ucx-py).
         if not re.match("branch-[0-9]{1,2}.[0-9]{2}", branch):
             continue
 


### PR DESCRIPTION
I noticed that PRs in `rmm` were failing with no successful runs in the past 7 days, but there ARE successful runs in the last 12 hours (and beyond).

https://github.com/rapidsai/rmm/actions/runs/16351381652/job/46198815927?pr=1987

However the error is complaining that

```
main has no successful runs of test.yaml in the last 7 days
```

I think due to the switch to the new branching model and the subsequent reversion of that switch, we're in a weird edge case.

The change here should fix the issue -- if a branch has no runs at all, we remove it from consideration.
