### PR TITLE
chore(ci): reduce pre-commit autoupdate frequency to quarterly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,7 @@
 # Copyright (c) 2024, NVIDIA CORPORATION.
 
 ci:
+  autoupdate_schedule: quarterly
   skip: [actionlint-docker]
 
 repos:


### PR DESCRIPTION
By default, `pre-commit.ci` checks for updates once a week.

This project uses some very actively-developed hooks, like `ruff`, meaning we get a PR like #72 almost every week.

This proposes reducing that check frequency to `quarterly`, to reduce the volume of notifications from this project.