### PR TITLE
Remove UCX-Py

### DIFF
--- a/check_nightly_success/check-nightly-success/check.py
+++ b/check_nightly_success/check-nightly-success/check.py
@@ -72,7 +72,7 @@ def main(
 
     for branch, branch_runs in branch_dict.items():
         # Only consider RAPIDS release branches, which have versions like
-        # '25.02' (RAPIDS) or '0.42' (ucxx, ucx-py).
+        # '25.10' (RAPIDS) or '0.46' (ucxx).
         if not re.match("branch-[0-9]{1,2}.[0-9]{2}", branch):
             continue
 


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/198

UCX-Py is being archived, therefore all mentions to the project should be removed.