### PR TITLE
fix: update branch matching regex to include 'main' for check-nightly-success

### DIFF
--- a/check_nightly_success/check-nightly-success/check.py
+++ b/check_nightly_success/check-nightly-success/check.py
@@ -73,7 +73,7 @@ def main(
     for branch, branch_runs in branch_dict.items():
         # Only consider RAPIDS release branches, which have versions like
         # '25.10' (RAPIDS) or '0.46' (ucxx).
-        if not re.match("branch-[0-9]{1,2}.[0-9]{2}", branch):
+        if not re.match(r"(main|branch-[0-9]{1,2}\.[0-9]{2})", branch):
             continue
 
         latest_success[branch] = None


### PR DESCRIPTION
Support a `main` branch as part of the check-nightly-success action.