### PR TITLE
Add changed-files action to use in changed-files workflow

### DIFF
--- a/changed-files/action.yml
+++ b/changed-files/action.yml
@@ -41,9 +41,8 @@ runs:
       shell: bash
       env:
         BASE_SHA: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.sha }}
-        REPOSITORY_URL: ${{ github.repositoryUrl }}
       run: |
-        git fetch --depth 1 "$REPOSITORY_URL" "$BASE_SHA"
+        git fetch --depth 1 origin "$BASE_SHA"
     - name: Get changed files
       id: changed-files
       uses: step-security/changed-files@95b56dadb92a30ca9036f16423fd3c088a71ee94 # v46.0.5


### PR DESCRIPTION
The `shared-workflows/.github/workflows/checks.yaml` workflow currently uses the `changed-files` workflow, but only needs it as an action. This PR puts the `changed-files` workflow into an action so that `checks` can use it.