### PR TITLE
Handle negative length jobs

### DIFF
--- a/telemetry-impls/summarize/send_trace.py
+++ b/telemetry-impls/summarize/send_trace.py
@@ -282,6 +282,10 @@ def process_job_blob(  # noqa: PLR0913
         logging.info("Job is empty (no start time) - bypassing")
         return last_timestamp
 
+    if job_last_timestamp < job_start:
+        logging.info("Job finish is before start - setting zero length job")
+        job_last_timestamp = job_start
+
     artifact_folder = Path.cwd() / f"telemetry-artifacts/telemetry-tools-artifacts-{job_id}"
     attributes = {}
     if (artifact_folder / "attrs").exists():


### PR DESCRIPTION
Sometimes, skipped jobs will have a finished timestamp less than the start, which displays as a very large duration. So, in this case, set the finish time to the start time to create a zero duration job.