### PR TITLE
check-nightly-success: adjust to new RAPIDS branching strategy

### DIFF
--- a/check_nightly_success/check-nightly-success/check.py
+++ b/check_nightly_success/check-nightly-success/check.py
@@ -56,13 +56,13 @@ def main(
     # Rather frustratingly, the workflow runs returned from the GitHub API can
     # have alternating ordering of `head_branch`
     # e.g.
-    #   run[0]['head_branch'] == "branch-25.02"
-    #   run[1]['head_branch'] == "branch-25.04"
-    #   run[2]['head_branch'] == "branch-25.02"
+    #   run[0]['head_branch'] == "release/25.02"
+    #   run[1]['head_branch'] == "release/25.04"
+    #   run[2]['head_branch'] == "release/25.02"
     #
     # In this situation, the behavior of `itertools.groupby` (previously used
     # here) is to only group _consecutive_ runs, so the results of the
-    # subsequent branch match (i.e.  the second group of `branch-25.02` runs)
+    # subsequent branch match (i.e.  the second group of `release/25.02` runs)
     # will overwrite the results of the first one, potentially overwriting a
     # previous success. The snippet below unifies the groups so it's more like a
     # SQL groupby and there is no chance of overwriting.
@@ -71,9 +71,9 @@ def main(
         branch_dict[run["head_branch"]].append(run)
 
     for branch, branch_runs in branch_dict.items():
-        # Only consider RAPIDS release branches, which have versions like
+        # Only consider 'main' and RAPIDS release branches, which have versions like
         # '25.10' (RAPIDS) or '0.46' (ucxx).
-        if not re.match(r"(main|branch-[0-9]{1,2}\.[0-9]{2})", branch):
+        if not re.match(r"(main|release/[0-9]{1,2}\.[0-9]{2})", branch):
             continue
 
         latest_success[branch] = None


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/224

RAPIDS projects now use `main` as their default development branch and `release/{YY.MM}` as the place releases get finalized.

This fixes the `check-nightly-success` check to account for that... I suspect it has been silently passing on release branches for a while 😬 😬 

