### PR TITLE
check-nightly-success: treat '0 runs' as success

### DIFF
--- a/check_nightly_success/README.md
+++ b/check_nightly_success/README.md
@@ -48,8 +48,8 @@ python ./check-nightly-success/check.py \
 
 If this succeeds, you'll see a `0` exit code and output text similar to the following:
 
-> Found 4 successful runs of workflow 'test.yaml' on branch 'main' in the previous 7 days (most recent: '2026-02-16 06:26:04+00:00'). View logs:
- - https://github.com/rapidsai/cudf/actions/runs/22052428055
+> Found 4 successful runs of workflow 'test.yaml' on branch 'main' in the previous 7 days (most recent: '2026-03-12 06:29:16+00:00'). View logs:
+ - https://github.com/rapidsai/cudf/actions/runs/22989549020
 
 ### Case 2: Fail when branch has 0 runs (of any status)
 
@@ -66,9 +66,28 @@ python ./check-nightly-success/check.py \
 
 That'll return exit code `1` and output similar to this:
 
-> requests.exceptions.RetryError: HTTPSConnectionPool(host='api.github.com', port=443): Max retries exceeded with url: /repos/rapidsai/build-planning/actions/workflows/test.yaml/runs?branch=main&status=success&per_page=100&created=%3E%3D2026-02-10 (Caused by ResponseError('too many 404 error responses'))
+> Repo 'rapidsai/build-planning' either does not have a workflow called 'test.yaml'. or has not ever had a single run of that workflow. Add / run 'test.yaml', then re-run this check.
 
-### Case 3: Success on new branches with only very-recent runs
+### Case 3: Succeed branches with 0 runs in the window.
+
+For repos where the workflow exists, a branch have 0 runs in the time window (regardless of status) is treated as a success.
+
+This prevents situations where this check blocks CI at the beginning of development
+on a new branch.
+
+```shell
+# intentionally using an archived repo to test this case
+GH_TOKEN=$(gh auth token) \
+python ./check-nightly-success/check.py \
+  --repo 'rapidsai/cuspatial' \
+  --branch 'release/26.04' \
+  --workflow-id 'test.yaml' \
+  --max-days-without-success 7
+```
+
+> There were 0 runs (successful or unsuccessful) of workflow 'test.yaml' on branch 'release/26.04' in the previous 14 days.
+
+### Case 4: Succeed on new branches with only very-recent runs
 
 Branches with only very-recent runs should be exempted from the check.
 
@@ -90,7 +109,7 @@ gh workflow run \
     -f sha="$(git rev-parse HEAD)" \
     -f build_type=nightly
 
-# (MANUAL - go to https://github.com/rapidsai/ucxx/actions/runs/22109183034 and manually cancel that run)
+# (MANUAL - go to https://github.com/rapidsai/ucxx/actions/workflows/test.yaml and manually cancel that run)
 
 # run the check
 GH_TOKEN=$(gh auth token) \
@@ -103,8 +122,8 @@ python ./check-nightly-success/check.py \
 
 That'll exit with code `0` and print something like this:
 
-> The oldest run of workflow 'test.yaml' on branch 'delete-me' was 0 days ago (2026-02-17 17:42:05+00:00).
-Because the latest run was less than 'max-days-without-success = 7' days ago, this workflow is exempted from check-nightly-success. The check will start failing if there is not a successful run in the next few days.
+> The oldest run of workflow 'test.yaml' on branch 'delete-me' was 0 days ago (2026-03-13 20:22:34+00:00).
+> Because the latest run was less than 'max-days-without-success = 7' days ago, this workflow is exempted from check-nightly-success. The check will start failing if there is not a successful run in the next few days.
 
 ### Other testing: pagination
 

--- a/check_nightly_success/check-nightly-success/check.py
+++ b/check_nightly_success/check-nightly-success/check.py
@@ -113,6 +113,37 @@ class GitHubClient:
             page_num += 1
         return data
 
+    def list_workflows(
+        self,
+        *,
+        repo: str,
+        headers: dict[str, str],
+        params: dict[str, int | str],
+    ) -> set[str]:
+        """List all the GitHub actions workflows for a repo"""
+        url = f"https://api.github.com/repos/{repo}/actions/workflows"
+        workflows: set[str] = set()
+        page_num = 1
+        while True:
+            print(f"requesting page {page_num} of workflows")
+            response = self._session.get(
+                url,
+                headers=headers,
+                params=params,
+                timeout=self.request_timeout_seconds,
+            )
+            response.raise_for_status()
+            data = response.json()
+            for w in data.get("workflows"):
+                workflows.add(os.path.basename(w["path"]))
+            next_url = response.links.get("next", {}).get("url")
+            if next_url is None:
+                break
+            url = next_url
+            params = None  # type: ignore[assignment]
+            page_num += 1
+        return workflows
+
 
 def main(
     *,
@@ -148,6 +179,25 @@ def main(
         request_timeout_seconds=request_timeout_seconds,
         retry_backoff_seconds=retry_backoff_seconds,
     )
+
+    # repo does not even have this workflow - failure
+    workflows = client.list_workflows(
+        repo=repo,
+        headers={"Authorization": f"token {GITHUB_TOKEN}"},
+        params={
+            # pull as many results per page as possible
+            "per_page": request_page_size,
+        },
+    )
+    if workflow_id not in workflows:
+        print(
+            f"Repo '{repo}' either does not have a workflow called '{workflow_id}'. "
+            "or has not ever had a single run of that workflow. "
+            f"Add / run '{workflow_id}', then re-run this check."
+        )
+        return ExitCode.FAILURE
+
+    # recent-enough, successful run = success
     successful_runs = client.get_all_runs(
         url=f"https://api.github.com/repos/{repo}/actions/workflows/{workflow_id}/runs",
         headers={"Authorization": f"token {GITHUB_TOKEN}"},
@@ -162,8 +212,6 @@ def main(
             "created": f">={oldest_date_to_pull.strftime('%Y-%m-%d')}",
         },
     )
-
-    # recent-enough, successful run = exit 0
     if successful_runs:
         most_recent_successful_run = max(successful_runs, key=lambda r: r.run_started_at)
         print(
@@ -173,12 +221,8 @@ def main(
         )
         return ExitCode.SUCCESS
 
-    # It's ok for there to be 0 successful runs if the branch is fairly new or the workflow hasn't been running on it
-    # very long.
-    #
-    # Code below looks for runs in the last `max_days_without_success * 2` days, to get an
-    # approximation of the entire history without having an unbounded "list all runs from all time" type of query
-    # (which could get expensive for very-active branches).
+    # Pull a wider window of runs (`max_days_without_success * 2` days), to enable
+    # checking if we're still within the new-branch grace period.
     lookback_days = max_days_without_success * 2
     oldest_date_to_pull = datetime.now(timezone.utc) - timedelta(days=lookback_days)
     all_runs = client.get_all_runs(
@@ -194,16 +238,16 @@ def main(
         },
     )
 
-    # Fail if there have not been any runs at all (to avoid silently skipping this check).
+    # 0 runs at all in the window = success
+    # This prevent the check from blocking CI when development begins on a new branch.
     if not all_runs:
         print(
             f"There were 0 runs (successful or unsuccessful) of workflow '{workflow_id}' on branch "
-            f"'{target_branch}' in the last {lookback_days} days. "
-            "To resolve this, run the workflow at least once or increase 'max-days-without-success'."
+            f"'{target_branch}' in the previous {lookback_days} days."
         )
-        return ExitCode.FAILURE
+        return ExitCode.SUCCESS
 
-    # If the oldest run on the branch was less than {max_days_without_success} ago, warn but allow the check to pass.
+    # oldest run on the branch was less than {max_days_without_success} ago = success
     oldest_run = min(all_runs, key=lambda r: r.run_started_at)
     days_since_oldest_run = (datetime.now(tz=timezone.utc) - oldest_run.run_started_at).days
     print(
@@ -218,7 +262,7 @@ def main(
         )
         return ExitCode.SUCCESS
 
-    # There isn't a recent-enough success and the branch isn't exempted... fail.
+    # not a recent-enough success and the branch isn't exempted = failure
     print(
         f"There were 0 successful runs of workflow '{workflow_id}' on branch '{target_branch}' in the last "
         f"{max_days_without_success} days."


### PR DESCRIPTION
Follow-up to #96 

We recently had an experience like the following:

1. first day of burndown, PRs start targeting new `release/26.04` branches
2. 0 nightlies have ever run on branch `release/26.04`
3. `check-nightly-success` fails on every PR in every repo, because "0 runs" is treated as a failure

This PR proposes changes to avoid that first-day-of-burndown pain... treating "0 runs on `<branch>`" as a successful run of the check.

This increases the risk of missing "nightlies are not running at all" issues like https://github.com/rapidsai/workflows/pull/106 and https://github.com/rapidsai/workflows/pull/109, but I think it's worth it in exchange for a smoother first day of burndown.

## Notes for Reviewers

### How I tested this

Ran each of the test cases in the README (modified here, see the diff).