### PR TITLE
fix: resolve template injection points

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,8 +12,11 @@ on:
 jobs:
   checks:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
+          persist-credentials: false
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,7 +13,7 @@ jobs:
   checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
-      - uses: pre-commit/action@v3.0.1
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/test-artifact-cleanup.yml
+++ b/.github/workflows/test-artifact-cleanup.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Create dummy file
         shell: bash
         run: echo "Dumbo" > file.txt
       - name: Upload dummy file
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: telemetry-tools-attrs-1234
           path: file.txt

--- a/.github/workflows/test-artifact-cleanup.yml
+++ b/.github/workflows/test-artifact-cleanup.yml
@@ -9,9 +9,14 @@ on:
 jobs:
   telemetry-setup:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Create dummy file
         shell: bash
         run: echo "Dumbo" > file.txt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,10 @@ repos:
       - id: check-added-large-files
       - id: check-yaml
       - id: end-of-file-fixer
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.24.1
+    hooks:
+      - id: zizmor
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.12
     hooks:

--- a/changed-files/action.yml
+++ b/changed-files/action.yml
@@ -36,7 +36,7 @@ runs:
   steps:
     - name: Get PR info
       id: get-pr-info
-      uses: nv-gha-runners/get-pr-info@main
+      uses: nv-gha-runners/get-pr-info@090577647b8ddc4e06e809e264f7881650ecdccf # main
     - name: Fetch changed files
       shell: bash
       env:

--- a/check_nightly_success/dispatch/action.yml
+++ b/check_nightly_success/dispatch/action.yml
@@ -31,6 +31,7 @@ runs:
         repository: ${{ env.SHARED_ACTIONS_REPO || 'rapidsai/shared-actions' }}
         ref: ${{ env.SHARED_ACTIONS_REF || 'main' }}
         path: ./shared-actions
+        persist-credentials: false
     - name: Run check-nightly-success
       uses: ./shared-actions/check_nightly_success/check-nightly-success
       with:

--- a/check_nightly_success/dispatch/action.yml
+++ b/check_nightly_success/dispatch/action.yml
@@ -26,7 +26,7 @@ runs:
   using: 'composite'
   steps:
     - name: Clone shared-actions repo
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         repository: ${{ env.SHARED_ACTIONS_REPO || 'rapidsai/shared-actions' }}
         ref: ${{ env.SHARED_ACTIONS_REF || 'main' }}

--- a/dockerhub-script/action.yml
+++ b/dockerhub-script/action.yml
@@ -38,7 +38,8 @@ runs:
         )
         echo "::add-mask::${HUB_TOKEN}"
 
-        . ${{ inputs.script }}
+        . "$SCRIPT"
       env:
+        SCRIPT: ${{ inputs.script }}
         DOCKERHUB_USER: ${{ inputs.DOCKERHUB_USER }}
         DOCKERHUB_TOKEN: ${{ inputs.DOCKERHUB_TOKEN }}

--- a/rapids-github-info/action.yml
+++ b/rapids-github-info/action.yml
@@ -28,15 +28,21 @@ runs:
     - name: Standardize repository information
       id: standardize-repo-info
       shell: bash
-      run: |
-        echo "RAPIDS_REPOSITORY=${{ inputs.repo || github.repository }}" | tee --append "${GITHUB_ENV}" "${GITHUB_OUTPUT}"
-        sha="${{ inputs.sha }}"
+      run: | # zizmor: ignore[github-env]
+        printf 'RAPIDS_REPOSITORY=%s\n' "$(printf '%s' "${INPUTS_REPO}" | tr -d '\n')" | tee --append "${GITHUB_ENV}" "${GITHUB_OUTPUT}"
+        sha="${INPUTS_SHA}"
         if [[ "${sha}" == "" ]]; then
           sha=$(git rev-parse HEAD)
         fi
-        echo "RAPIDS_SHA=${sha}" | tee --append "${GITHUB_ENV}" "${GITHUB_OUTPUT}"
-        echo "RAPIDS_REF_NAME=${{ inputs.branch || github.ref_name }}" | tee --append "${GITHUB_ENV}" "${GITHUB_OUTPUT}"
-        echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" | tee --append "${GITHUB_ENV}" "${GITHUB_OUTPUT}"
-        if [[ -n "${{ inputs.build_workflow_name }}" ]]; then
-          echo "RAPIDS_BUILD_WORKFLOW_NAME=${{ inputs.build_workflow_name }}" | tee --append "${GITHUB_ENV}" "${GITHUB_OUTPUT}"
+        printf 'RAPIDS_SHA=%s\n' "$(printf '%s' "${sha}" | tr -d '\n')" | tee --append "${GITHUB_ENV}" "${GITHUB_OUTPUT}"
+        printf 'RAPIDS_REF_NAME=%s\n' "$(printf '%s' "${INPUTS_BRANCH}" | tr -d '\n')" | tee --append "${GITHUB_ENV}" "${GITHUB_OUTPUT}"
+        printf 'RAPIDS_NIGHTLY_DATE=%s\n' "$(printf '%s' "${INPUTS_DATE}" | tr -d '\n')" | tee --append "${GITHUB_ENV}" "${GITHUB_OUTPUT}"
+        if [[ -n "${INPUTS_BUILD_WORKFLOW_NAME}" ]]; then
+          printf 'RAPIDS_BUILD_WORKFLOW_NAME=%s\n' "$(printf '%s' "${INPUTS_BUILD_WORKFLOW_NAME}" | tr -d '\n')" | tee --append "${GITHUB_ENV}" "${GITHUB_OUTPUT}"
         fi
+      env:
+        INPUTS_REPO: ${{ inputs.repo || github.repository }}
+        INPUTS_BRANCH: ${{ inputs.branch || github.ref_name }}
+        INPUTS_SHA: ${{ inputs.sha }}
+        INPUTS_DATE: ${{ inputs.date }}
+        INPUTS_BUILD_WORKFLOW_NAME: ${{ inputs.build_workflow_name }}

--- a/setup-sccache-dist/action.yml
+++ b/setup-sccache-dist/action.yml
@@ -51,9 +51,11 @@ runs:
         SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE: "${{inputs.fallback-to-local-compile}}"
         SCCACHE_DIST_MAX_RETRIES: "${{inputs.max-retries}}"
         SCCACHE_DIST_REQUEST_TIMEOUT: "${{inputs.request-timeout}}"
-      run: |
+        GHA_RUN_ID: "${{github.run_id}}"
+        GHA_RUN_ATTEMPT: "${{github.run_attempt}}"
+      run: | # zizmor: ignore[github-env]
         cat <<EOF | tee -a "$GITHUB_ENV"
-        GHA_CACHE_SLUG=${{github.run_id}}-${{github.run_attempt}}-$RANDOM
+        GHA_CACHE_SLUG=${GHA_RUN_ID}-${GHA_RUN_ATTEMPT}-$RANDOM
         SCCACHE_REPO=$SCCACHE_REPO
         SCCACHE_VERSION=$SCCACHE_VERSION
         SCCACHE_ERROR_LOG=$SCCACHE_ERROR_LOG

--- a/telemetry-dispatch-setup/action.yml
+++ b/telemetry-dispatch-setup/action.yml
@@ -17,7 +17,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: rapidsai/shared-actions/telemetry-impls/load-then-clone@main
+    - uses: rapidsai/shared-actions/telemetry-impls/load-then-clone@c7f296f0a71159e86f1a676b8fd1a733c54f5563 # main
       id: has_base_env_var_artifact
     - name: Output that setup was skipped if the base env var artifact was not found
       if: steps.has_base_env_var_artifact.outputs.artifact_found == 'false'

--- a/telemetry-dispatch-setup/action.yml
+++ b/telemetry-dispatch-setup/action.yml
@@ -17,7 +17,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: rapidsai/shared-actions/telemetry-impls/load-then-clone@c7f296f0a71159e86f1a676b8fd1a733c54f5563 # main
+    - uses: rapidsai/shared-actions/telemetry-impls/load-then-clone@main # zizmor: ignore[unpinned-uses]
       id: has_base_env_var_artifact
     - name: Output that setup was skipped if the base env var artifact was not found
       if: steps.has_base_env_var_artifact.outputs.artifact_found == 'false'

--- a/telemetry-dispatch-setup/action.yml
+++ b/telemetry-dispatch-setup/action.yml
@@ -30,8 +30,8 @@ runs:
       if: steps.has_base_env_var_artifact.outputs.artifact_found == 'true'
     - shell: bash
       if: steps.has_base_env_var_artifact.outputs.artifact_found == 'true'
-      run:
-        echo JOB_ID="$(cat job_info.json | jq -r '.id')" >> ${GITHUB_ENV};
+      run: # zizmor: ignore[github-env]
+        printf 'JOB_ID=%s\n' "$(cat job_info.json | jq -r '.id' | tr -d '\n')" >> ${GITHUB_ENV};
     # overrides loaded value.
     - name: Set OTEL_SERVICE_NAME from job
       if: steps.has_base_env_var_artifact.outputs.artifact_found == 'true'
@@ -39,16 +39,18 @@ runs:
     - name: Add attribute metadata beyond the stashed basic stuff
       if: steps.has_base_env_var_artifact.outputs.artifact_found == 'true'
       shell: bash
-      run:
+      env:
+        EXTRA_ATTRIBUTES: ${{ inputs.extra_attributes }}
+      run: # zizmor: ignore[github-env]
         attributes="${OTEL_RESOURCE_ATTRIBUTES}";
         labels="$(jq -r '.labels | join(" ")' job_info.json)";
         if [ "${labels}" != "" ]; then
           attributes="${attributes},rapids.labels=${labels}";
         fi;
-        if [ "${{ inputs.extra_attributes }}" != "" ]; then
-          attributes="${attributes},${{ inputs.extra_attributes }}";
+        if [ "${EXTRA_ATTRIBUTES}" != "" ]; then
+          attributes="${attributes},${EXTRA_ATTRIBUTES}";
         fi;
         attributes=$(echo "${attributes}" | sed 's/^,//');
         attributes=$(echo "${attributes}" | sed 's/,$//');
         attributes=$(echo "${attributes}" | sed -r "s/(git.job_url=[^,]+)/\1\/job\/${JOB_ID}/");
-        echo OTEL_RESOURCE_ATTRIBUTES="${attributes}" >> ${GITHUB_ENV};
+        printf 'OTEL_RESOURCE_ATTRIBUTES=%s\n' "$(printf '%s' "${attributes}" | tr -d '\n')" >> ${GITHUB_ENV};

--- a/telemetry-dispatch-stash-base-env-vars/action.yml
+++ b/telemetry-dispatch-stash-base-env-vars/action.yml
@@ -20,5 +20,6 @@ runs:
         repository: ${{ env.SHARED_ACTIONS_REPO || 'rapidsai/shared-actions' }}
         ref: ${{ env.SHARED_ACTIONS_REF || 'main' }}
         path: ./shared-actions
+        persist-credentials: false
     - name: Stash base env vars
       uses: ./shared-actions/telemetry-impls/stash-base-env-vars

--- a/telemetry-dispatch-stash-base-env-vars/action.yml
+++ b/telemetry-dispatch-stash-base-env-vars/action.yml
@@ -15,7 +15,7 @@ runs:
     # We can't use the load-then-clone action because the env vars file
     # that it needs is something that we create here.
     - name: Clone shared-actions repo
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         repository: ${{ env.SHARED_ACTIONS_REPO || 'rapidsai/shared-actions' }}
         ref: ${{ env.SHARED_ACTIONS_REF || 'main' }}

--- a/telemetry-dispatch-stash-job-artifacts/action.yml
+++ b/telemetry-dispatch-stash-job-artifacts/action.yml
@@ -10,7 +10,7 @@ description: |
 runs:
   using: 'composite'
   steps:
-    - uses: rapidsai/shared-actions/telemetry-impls/load-then-clone@main
+    - uses: rapidsai/shared-actions/telemetry-impls/load-then-clone@c7f296f0a71159e86f1a676b8fd1a733c54f5563 # main
       id: has_base_env_var_artifact
     # Stash current job's OTEL_RESOURCE_ATTRIBUTES and any files in the telemetry-artifacts directory
     - name: Stash job artifacts

--- a/telemetry-dispatch-stash-job-artifacts/action.yml
+++ b/telemetry-dispatch-stash-job-artifacts/action.yml
@@ -10,7 +10,7 @@ description: |
 runs:
   using: 'composite'
   steps:
-    - uses: rapidsai/shared-actions/telemetry-impls/load-then-clone@c7f296f0a71159e86f1a676b8fd1a733c54f5563 # main
+    - uses: rapidsai/shared-actions/telemetry-impls/load-then-clone@main # zizmor: ignore[unpinned-uses]
       id: has_base_env_var_artifact
     # Stash current job's OTEL_RESOURCE_ATTRIBUTES and any files in the telemetry-artifacts directory
     - name: Stash job artifacts

--- a/telemetry-dispatch-summarize/action.yml
+++ b/telemetry-dispatch-summarize/action.yml
@@ -11,7 +11,7 @@ description: |
 runs:
   using: 'composite'
   steps:
-    - uses: rapidsai/shared-actions/telemetry-impls/load-then-clone@main
+    - uses: rapidsai/shared-actions/telemetry-impls/load-then-clone@c7f296f0a71159e86f1a676b8fd1a733c54f5563 # main
       id: has_base_env_var_artifact
     - uses: ./shared-actions/telemetry-impls/summarize
       if: steps.has_base_env_var_artifact.outputs.artifact_found == 'true'

--- a/telemetry-dispatch-summarize/action.yml
+++ b/telemetry-dispatch-summarize/action.yml
@@ -11,7 +11,7 @@ description: |
 runs:
   using: 'composite'
   steps:
-    - uses: rapidsai/shared-actions/telemetry-impls/load-then-clone@c7f296f0a71159e86f1a676b8fd1a733c54f5563 # main
+    - uses: rapidsai/shared-actions/telemetry-impls/load-then-clone@main # zizmor: ignore[unpinned-uses]
       id: has_base_env_var_artifact
     - uses: ./shared-actions/telemetry-impls/summarize
       if: steps.has_base_env_var_artifact.outputs.artifact_found == 'true'

--- a/telemetry-dispatch-write-summary/action.yml
+++ b/telemetry-dispatch-write-summary/action.yml
@@ -24,6 +24,7 @@ runs:
         repository: ${{ env.SHARED_ACTIONS_REPO || 'rapidsai/shared-actions' }}
         ref: ${{ env.SHARED_ACTIONS_REF || 'main' }}
         path: ./shared-actions
+        persist-credentials: false
     # This is necessary because this action will generally be run in a job separately from
     # where the env vars are set
     - name: Load base environment variables

--- a/telemetry-dispatch-write-summary/action.yml
+++ b/telemetry-dispatch-write-summary/action.yml
@@ -19,7 +19,7 @@ runs:
   using: 'composite'
   steps:
     - name: Clone shared-actions repo
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         repository: ${{ env.SHARED_ACTIONS_REPO || 'rapidsai/shared-actions' }}
         ref: ${{ env.SHARED_ACTIONS_REF || 'main' }}

--- a/telemetry-impls/clean-up-artifacts/action.yml
+++ b/telemetry-impls/clean-up-artifacts/action.yml
@@ -8,7 +8,7 @@ runs:
   using: 'composite'
   steps:
     - name: Clean up telemetry files
-      uses: actions/github-script@v8
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       if: runner.debug != '1'
       with:
         retries: 3

--- a/telemetry-impls/ensure-otel-cli-available/action.yml
+++ b/telemetry-impls/ensure-otel-cli-available/action.yml
@@ -13,7 +13,9 @@ runs:
   steps:
     - shell: bash
       id: install-otel-cli
-      run:
+      env:
+        OTEL_CLI_VERSION: ${{ inputs.otel_cli_version }}
+      run: # zizmor: ignore[github-env]
 
         mkdir -p bin;
         echo $(pwd)/bin >> $GITHUB_PATH;
@@ -24,7 +26,7 @@ runs:
           else
             ARCH="arm64";
           fi;
-          curl -L -o otel-cli-${ARCH}.tar.gz https://github.com/equinix-labs/otel-cli/releases/download/v${{ inputs.otel_cli_version}}/otel-cli_${{ inputs.otel_cli_version}}_linux_${ARCH}.tar.gz;
+          curl -L -o otel-cli-${ARCH}.tar.gz https://github.com/equinix-labs/otel-cli/releases/download/v${OTEL_CLI_VERSION}/otel-cli_${OTEL_CLI_VERSION}_linux_${ARCH}.tar.gz;
           tar -zxf  otel-cli-${ARCH}.tar.gz;
           mv otel-cli ./bin/;
           rm -rf otel-cli-${ARCH}.tar.gz;

--- a/telemetry-impls/github-actions-job-info/action.yml
+++ b/telemetry-impls/github-actions-job-info/action.yml
@@ -18,7 +18,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/github-script@v8
+    - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       id: get-job-info
       env:
         ALL_JOBS: "${{ inputs.all_jobs }}"

--- a/telemetry-impls/load-base-env-vars/action.yml
+++ b/telemetry-impls/load-base-env-vars/action.yml
@@ -15,7 +15,7 @@ runs:
       # the ${!VARIABLE} syntax is called "indirect expansion" and it is kind of equivalent to ${${env_var_name}}
       #      in other words, expand to find the variable name, then dereference that variable name
       # The goofy env_var_value filtering through tr is to ensure that the strings don't include quotes.
-      run: |
+      run: | # zizmor: ignore[github-env]
         while read LINE; do
           env_var_name="$( cut -d '=' -f 1 <<< "$LINE" )";
           if [ "${!env_var_name}" = "" ]; then

--- a/telemetry-impls/load-then-clone/action.yml
+++ b/telemetry-impls/load-then-clone/action.yml
@@ -30,7 +30,7 @@ runs:
           | grep -q . && echo 'true' || echo 'false');
         echo "artifact_found=${artifact_found}" | tee -a $GITHUB_OUTPUT;
     - name: Download base environment variables file
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       if: steps.check-artifact-exists.outputs.artifact_found == 'true'
       with:
         name: telemetry-tools-env-vars
@@ -55,7 +55,7 @@ runs:
           fi
         done <telemetry-artifacts/telemetry-env-vars
     - name: Clone shared-actions repo with loaded env vars
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         repository: ${{ env.SHARED_ACTIONS_REPO || 'rapidsai/shared-actions' }}
         ref: ${{ env.SHARED_ACTIONS_REF || 'main' }}

--- a/telemetry-impls/load-then-clone/action.yml
+++ b/telemetry-impls/load-then-clone/action.yml
@@ -44,7 +44,7 @@ runs:
       # the ${!VARIABLE} syntax is called "indirect expansion" and it is kind of equivalent to ${${env_var_name}}
       #      in other words, expand to find the variable name, then dereference that variable name
       # The goofy env_var_value filtering through tr is to ensure that the strings don't include quotes.
-      run: |
+      run: | # zizmor: ignore[github-env]
         while read LINE; do
           env_var_name="$( cut -d '=' -f 1 <<< "$LINE" )";
           if [ "${!env_var_name}" = "" ]; then

--- a/telemetry-impls/load-then-clone/action.yml
+++ b/telemetry-impls/load-then-clone/action.yml
@@ -60,3 +60,4 @@ runs:
         repository: ${{ env.SHARED_ACTIONS_REPO || 'rapidsai/shared-actions' }}
         ref: ${{ env.SHARED_ACTIONS_REF || 'main' }}
         path: ./shared-actions
+        persist-credentials: false

--- a/telemetry-impls/set-otel-service-name/action.yml
+++ b/telemetry-impls/set-otel-service-name/action.yml
@@ -27,5 +27,7 @@ runs:
         echo JOB_NAME="$(cat job_info.json | jq -r '.name')" >> ${GITHUB_OUTPUT};
     - shell: bash
       id: set-otel-service-name-env
-      run: |
-        echo OTEL_SERVICE_NAME="${{ steps.get-job-name.outputs.JOB_NAME }}" >> ${GITHUB_ENV};
+      env:
+        JOB_NAME: ${{ steps.get-job-name.outputs.JOB_NAME }}
+      run: | # zizmor: ignore[github-env]
+        printf 'OTEL_SERVICE_NAME=%s\n' "$(printf '%s' "${JOB_NAME}" | tr -d '\n')" >> ${GITHUB_ENV};

--- a/telemetry-impls/stash-base-env-vars/action.yml
+++ b/telemetry-impls/stash-base-env-vars/action.yml
@@ -31,7 +31,7 @@ runs:
         SHARED_ACTIONS_REF=${SHARED_ACTIONS_REF:-main}
         EOF
     - name: Upload env vars file
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: telemetry-tools-env-vars
         path: telemetry-env-vars

--- a/telemetry-impls/stash-job-artifacts/action.yml
+++ b/telemetry-impls/stash-job-artifacts/action.yml
@@ -17,7 +17,7 @@ runs:
         printf "%s\n" "${values[@]}" > telemetry-artifacts/attrs;
 
     - name: Upload attr file and any other files
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: telemetry-tools-artifacts-${{ env.JOB_ID }}
         path: telemetry-artifacts

--- a/telemetry-impls/summarize/action.yml
+++ b/telemetry-impls/summarize/action.yml
@@ -6,7 +6,7 @@ runs:
   using: 'composite'
   steps:
     - name: Setup python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: 3.11
         cache: 'pip'
@@ -20,13 +20,13 @@ runs:
       with:
         all_jobs: true
     - name: Upload job JSON file if debugging
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: runner.debug == '1'
       with:
         name: telemetry-tools-all_jobs.json
         path: all_jobs.json
     # This downloads ALL of the files that we have collected from each job.
-    - uses: actions/download-artifact@v8
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         path: telemetry-artifacts
         pattern: telemetry-tools-*

--- a/telemetry-impls/summarize/action.yml
+++ b/telemetry-impls/summarize/action.yml
@@ -34,13 +34,13 @@ runs:
 
     - name: Run parse and send trace/spans to endpoint
       shell: bash
-      run: |
+      run: | # zizmor: ignore[github-env]
         OTEL_SERVICE_NAME=${OTEL_SERVICE_NAME:-${GITHUB_WORKFLOW}-${GITHUB_REPOSITORY#*/}}
         export OTEL_SERVICE_NAME
-        echo "OTEL_SERVICE_NAME=${OTEL_SERVICE_NAME}" >> $GITHUB_ENV
+        printf 'OTEL_SERVICE_NAME=%s\n' "$(printf '%s' "${OTEL_SERVICE_NAME}" | tr -d '\n')" >> $GITHUB_ENV
         TRACEPARENT=$(./shared-actions/telemetry-impls/traceparent.sh "${OTEL_SERVICE_NAME}")
         export TRACEPARENT
-        echo "TRACEPARENT=${TRACEPARENT}" >> $GITHUB_ENV
+        printf 'TRACEPARENT=%s\n' "$(printf '%s' "${TRACEPARENT}" | tr -d '\n')" >> $GITHUB_ENV
 
         ls -lR telemetry-artifacts
         timeout 5m python3 ./shared-actions/telemetry-impls/summarize/send_trace.py

--- a/telemetry-impls/traceparent/action.yml
+++ b/telemetry-impls/traceparent/action.yml
@@ -41,6 +41,7 @@ runs:
 
     - shell: bash
       id: shell
-      run: |
-        echo "TRACEPARENT=$(rapids-get-telemetry-traceparent "${OTEL_SERVICE_NAME}")" >> ${GITHUB_OUTPUT}
-        echo "TRACEPARENT=$(rapids-get-telemetry-traceparent "${OTEL_SERVICE_NAME}")" >> ${GITHUB_ENV}
+      run: | # zizmor: ignore[github-env]
+        TRACEPARENT="$(rapids-get-telemetry-traceparent "${OTEL_SERVICE_NAME}")"
+        printf 'TRACEPARENT=%s\n' "${TRACEPARENT}" >> ${GITHUB_OUTPUT}
+        printf 'TRACEPARENT=%s\n' "${TRACEPARENT}" >> ${GITHUB_ENV}


### PR DESCRIPTION
This PR fixes several classes of security vulnerability. The diff isn't as big as I had feared, but I've also binned each set of vulnerability mitigation into separate commits for ease of review.

### Changes

- all upstream actions are pinned to SHAs (with versions in comments, so `renovate` still works
- all permissions are explicitly set now, and we don't persist credentials
- all inputs are sanitized -- this is done by moving inputs to env-variables and referencing those - there are a few places where I'm also trimming out newlines from inputs, I don't think that's actually necessary but it doesn't hurt.
- added `zizmor` to pre-commit so these fixes stay in place

Keeping this as a draft for the moment.
I'll open a PR in a few RAPIDS repos pointing at this branch to confirm this doesn't break anything.
