### PR TITLE
Diff against merge-base in changed-files action

### DIFF
--- a/changed-files/action.yml
+++ b/changed-files/action.yml
@@ -37,17 +37,38 @@ runs:
     - name: Get PR info
       id: get-pr-info
       uses: nv-gha-runners/get-pr-info@090577647b8ddc4e06e809e264f7881650ecdccf # main
-    - name: Fetch changed files
+    - name: Compute merge-base
+      id: merge-base
       shell: bash
       env:
         BASE_SHA: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.sha }}
+        HEAD_SHA: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).head.sha }}
+      # Diff against the merge-base (three-dot semantics) rather than the tip
+      # of the base branch, so files changed upstream after the PR branched
+      # are not falsely attributed to the PR.
       run: |
-        git fetch --depth 1 origin "$BASE_SHA"
+        set -euo pipefail
+        depth=50
+        max_depth=6400
+        while :; do
+          git fetch --depth="$depth" origin "$BASE_SHA" "$HEAD_SHA"
+          if merge_base=$(git merge-base "$BASE_SHA" "$HEAD_SHA" 2>/dev/null); then
+            echo "Found merge-base $merge_base at depth $depth"
+            echo "merge_base=$merge_base" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$depth" -ge "$max_depth" ]; then
+            echo "::warning::Could not find merge-base within depth $max_depth; falling back to base SHA $BASE_SHA"
+            echo "merge_base=$BASE_SHA" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          depth=$((depth * 2))
+        done
     - name: Get changed files
       id: changed-files
       uses: step-security/changed-files@2e07db73e5ccdb319b9a6c7766bd46d39d304bad # v47.0.5
       with:
-        base_sha: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.sha }}
+        base_sha: ${{ steps.merge-base.outputs.merge_base }}
         sha: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).head.sha }}
         files_yaml: ${{ inputs.files_yaml }}
         write_output_files: true


### PR DESCRIPTION
## Summary

The `changed-files` action passed `pr-info.base.sha` (current tip of the base branch) as `base_sha` to `step-security/changed-files`, which produces a **two-dot** diff `base..head`. When the base branch advances after a PR branches, this diff falsely reports upstream-only commits' files as changed in the PR, defeating path-based job filtering in consuming repos.

This switches the comparison to **three-dot** semantics by computing `git merge-base base head` first and passing that as `base_sha`. The calling workflow's checkout is shallow, so we fetch progressively deeper (50 → 6400 commits) until the merge-base is reachable, with a graceful fallback to the original `base.sha` if it isn't.

## Concrete example of the bug

cudf PR [#22191](https://github.com/rapidsai/cudf/pull/22191) only touches 12 files under `python/cudf_polars/**`, but the [Apr 28 run](https://github.com/rapidsai/cudf/actions/runs/25460661453) fired `conda-python-cudf-tests`, `wheel-tests-cudf`, `wheel-tests-dask-cudf`, `narwhals-tests`, `pandas-tests`, `unit-tests-cudf-pandas`, `third-party-integration-tests-cudf-pandas`, etc. — all of which have `if:` filters that should have skipped them.

The `changed-files` job's `transformed-output` showed every group `true`:
```
{"build_docs":true, ..., "neither_cudf_polars_nor_dask_cudf":true, "not_cudf_polars":true, ...}
```

Reproduced locally on the same SHAs:

| Diff | Result |
|---|---|
| `d24f7703fa..bc584d76` (two-dot, current behavior) | 73 files — includes cpp/, conda/recipes/, ci/test_cpp.sh, etc. |
| `d24f7703fa...bc584d76` (three-dot, this PR) | 12 files, all `python/cudf_polars/**` |

The merge-base resolves to `e0769e0d` on the first iteration at depth=50.

## Test plan

- [ ] Verify on a fresh consuming-repo PR that's behind its base branch — only path-relevant jobs should fire.
- [ ] Verify on a PR that's up-to-date with main — behavior unchanged (merge-base equals base.sha).
- [ ] Verify against a forced very-old PR — depth doubling reaches merge-base or falls back cleanly without error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)