### PR TITLE
use full semver tags for third-party actions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
           persist-credentials: false

--- a/.github/workflows/test-artifact-cleanup.yml
+++ b/.github/workflows/test-artifact-cleanup.yml
@@ -14,14 +14,14 @@ jobs:
       actions: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Create dummy file
         shell: bash
         run: echo "Dumbo" > file.txt
       - name: Upload dummy file
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: telemetry-tools-attrs-1234
           path: file.txt

--- a/build-devcontainer/action.yml
+++ b/build-devcontainer/action.yml
@@ -30,13 +30,13 @@ runs:
   using: composite
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.2
       with:
         node-version: '24'
 
     - if: runner.environment != 'self-hosted'
       name: Set up QEMU
-      uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
+      uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
     - name: Create docker context
       shell: bash
@@ -44,13 +44,13 @@ runs:
 
     - if: runner.environment != 'self-hosted'
       name: Setup docker buildx on github-hosted runners
-      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
       with:
         endpoint: builder
 
     - if: runner.environment == 'self-hosted'
       name: Setup docker buildx on self-hosted runners
-      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
       with:
         buildkitd-config: /etc/buildkit/buildkitd.toml
         buildkitd-flags: --config /etc/buildkit/buildkitd.toml

--- a/check_nightly_success/dispatch/action.yml
+++ b/check_nightly_success/dispatch/action.yml
@@ -26,7 +26,7 @@ runs:
   using: 'composite'
   steps:
     - name: Clone shared-actions repo
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: ${{ env.SHARED_ACTIONS_REPO || 'rapidsai/shared-actions' }}
         ref: ${{ env.SHARED_ACTIONS_REF || 'main' }}

--- a/telemetry-dispatch-stash-base-env-vars/action.yml
+++ b/telemetry-dispatch-stash-base-env-vars/action.yml
@@ -15,7 +15,7 @@ runs:
     # We can't use the load-then-clone action because the env vars file
     # that it needs is something that we create here.
     - name: Clone shared-actions repo
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: ${{ env.SHARED_ACTIONS_REPO || 'rapidsai/shared-actions' }}
         ref: ${{ env.SHARED_ACTIONS_REF || 'main' }}

--- a/telemetry-dispatch-write-summary/action.yml
+++ b/telemetry-dispatch-write-summary/action.yml
@@ -19,7 +19,7 @@ runs:
   using: 'composite'
   steps:
     - name: Clone shared-actions repo
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: ${{ env.SHARED_ACTIONS_REPO || 'rapidsai/shared-actions' }}
         ref: ${{ env.SHARED_ACTIONS_REF || 'main' }}

--- a/telemetry-impls/load-then-clone/action.yml
+++ b/telemetry-impls/load-then-clone/action.yml
@@ -30,7 +30,7 @@ runs:
           | grep -q . && echo 'true' || echo 'false');
         echo "artifact_found=${artifact_found}" | tee -a $GITHUB_OUTPUT;
     - name: Download base environment variables file
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       if: steps.check-artifact-exists.outputs.artifact_found == 'true'
       with:
         name: telemetry-tools-env-vars
@@ -55,7 +55,7 @@ runs:
           fi
         done <telemetry-artifacts/telemetry-env-vars
     - name: Clone shared-actions repo with loaded env vars
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: ${{ env.SHARED_ACTIONS_REPO || 'rapidsai/shared-actions' }}
         ref: ${{ env.SHARED_ACTIONS_REF || 'main' }}

--- a/telemetry-impls/stash-base-env-vars/action.yml
+++ b/telemetry-impls/stash-base-env-vars/action.yml
@@ -31,7 +31,7 @@ runs:
         SHARED_ACTIONS_REF=${SHARED_ACTIONS_REF:-main}
         EOF
     - name: Upload env vars file
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: telemetry-tools-env-vars
         path: telemetry-env-vars

--- a/telemetry-impls/stash-job-artifacts/action.yml
+++ b/telemetry-impls/stash-job-artifacts/action.yml
@@ -17,7 +17,7 @@ runs:
         printf "%s\n" "${values[@]}" > telemetry-artifacts/attrs;
 
     - name: Upload attr file and any other files
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: telemetry-tools-artifacts-${{ env.JOB_ID }}
         path: telemetry-artifacts

--- a/telemetry-impls/summarize/action.yml
+++ b/telemetry-impls/summarize/action.yml
@@ -6,7 +6,7 @@ runs:
   using: 'composite'
   steps:
     - name: Setup python
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: 3.11
         cache: 'pip'
@@ -20,13 +20,13 @@ runs:
       with:
         all_jobs: true
     - name: Upload job JSON file if debugging
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: runner.debug == '1'
       with:
         name: telemetry-tools-all_jobs.json
         path: all_jobs.json
     # This downloads ALL of the files that we have collected from each job.
-    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         path: telemetry-artifacts
         pattern: telemetry-tools-*


### PR DESCRIPTION
Closes #108

Similar to https://github.com/rapidsai/shared-workflows/pull/558

Using full semantic versions in the comments read by `dependabot` / `renovate` makes auto-generated PRs easier to review, for example because it allows them to automatically grab a link to release notes.
