### PR TITLE
vendor trigger workflow and wait

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,3 +43,7 @@ repos:
           - "--config-file=pyproject.toml"
           - "check_nightly_success/"
         pass_filenames: false
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
+    hooks:
+      - id: shellcheck

--- a/telemetry-dispatch-write-summary/action.yml
+++ b/telemetry-dispatch-write-summary/action.yml
@@ -1,7 +1,7 @@
 name: dispatch-summarize
 description: |
   Clones a particular branch/ref of a shared-actions repo, then calls its telemetry summarize
-  action. The summarize action downloads and parses Github job metadata, and creates
+  action. The summarize action downloads and parses GitHub job metadata, and creates
   OpenTelemetry spans from the job metadata. These are sent to the configured OTLP receiver/endpoint.
 
   DEPRECATED: this is here to ensure a smooth transition while rolling out https://github.com/rapidsai/shared-actions/pull/28

--- a/telemetry-impls/github-actions-job-info/action.yml
+++ b/telemetry-impls/github-actions-job-info/action.yml
@@ -1,4 +1,4 @@
-name: 'Github Actions Job info'
+name: 'GitHub Actions Job info'
 description: |
   Obtains job metadata from the GitHub Actions API.
   Provides one of two files on disk:

--- a/telemetry-impls/summarize/send_trace.py
+++ b/telemetry-impls/summarize/send_trace.py
@@ -80,7 +80,7 @@ def parse_attributes(attrs: os.PathLike | str | None) -> dict[str, str]:
 
 
 def date_str_to_epoch(date_str: str, value_if_not_set: int | None = 0) -> int:
-    """Github logs come in RFC 3339; this converts to nanoseconds since epoch."""
+    """GitHub logs come in RFC 3339; this converts to nanoseconds since epoch."""
     if date_str:
         # replace bit is to attach the UTC timezone to our datetime object, so
         # that it doesn't "help" us by adjusting our string value, which is

--- a/telemetry-impls/traceparent.sh
+++ b/telemetry-impls/traceparent.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 # This emits a TRACEPARENT, which follows the w3c trace context standard.
 # https://www.w3.org/TR/trace-context/
 #
@@ -21,8 +23,6 @@ if [ "$JOB_NAME" = "" ]; then
     echo "ERROR: JOB_NAME (first parameter) is empty. This means your trace doesn't identify anything."
     exit 1
 fi
-
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 sha="$(echo "${GITHUB_REPOSITORY}+${GITHUB_RUN_ID}+${GITHUB_RUN_ATTEMPT}" | sha256sum | cut -f1 -d' ')"
 TRACE_ID="${sha:0:32}"

--- a/trigger-workflow-and-wait/Dockerfile
+++ b/trigger-workflow-and-wait/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.15.0
+
+RUN apk update && \
+    apk --no-cache add curl jq coreutils
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["sh", "/entrypoint.sh"]

--- a/trigger-workflow-and-wait/Dockerfile
+++ b/trigger-workflow-and-wait/Dockerfile
@@ -1,7 +1,12 @@
 FROM alpine:3.15.0
 
-RUN apk update && \
-    apk --no-cache add curl jq coreutils
+RUN <<EOF
+apk update
+apk --no-cache add \
+    coreutils \
+    curl \
+    jq
+EOF
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/trigger-workflow-and-wait/LICENSE
+++ b/trigger-workflow-and-wait/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Convictional, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/trigger-workflow-and-wait/LICENSE
+++ b/trigger-workflow-and-wait/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2020 Convictional, Inc.
+Copyright (c) 2024-2026, NVIDIA CORPORATION.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/trigger-workflow-and-wait/README.md
+++ b/trigger-workflow-and-wait/README.md
@@ -4,20 +4,20 @@ GitHub Action for trigger a workflow from another workflow. The action then wait
 
 ## Inputs
 
-| Input Name            | Required   | Default     | Description           |
-| ---------------------    | ---------- | ----------- | --------------------- |
-| `owner`                  | True       | N/A         | The owner of the repository where the workflow is contained. |
-| `repo`                   | True       | N/A         | The repository where the workflow is contained. |
-| `github_token`           | True       | N/A         | The GitHub access token with access to the repository. Its recommended you put it under secrets. |
-| `workflow_file_name`     | True       | N/A         | The reference point. For example, you could use main.yml. |
-| `github_user`            | False      | N/A         | The name of the GitHub user whose access token is being used to trigger the workflow. |
-| `ref`                    | False      | main        | The reference of the workflow run. The reference can be a branch, tag, or a commit SHA. |
-| `wait_interval`          | False      | 10          | The number of seconds delay between checking for result of run. |
-| `client_payload`         | False      | `{}`        | Payload to pass to the workflow, must be a JSON string |
-| `propagate_failure`      | False      | `true`      | Fail current job if downstream job fails. |
-| `trigger_workflow`       | False      | `true`      | Trigger the specified workflow. |
-| `wait_workflow`          | False      | `true`      | Wait for workflow to finish. |
-| `summarize`              | False      | `false`     | Print downstream job URL and ID to workflow job summary |
+| Input Name           | Required | Default | Description                                                                                            |
+| -------------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------ |
+| `owner`              | True     | N/A     | Owner of the repository where the workflow is contained.                                               |
+| `repo`               | True     | N/A     | Repository where the workflow is contained.                                                            |
+| `github_token`       | True     | N/A     | GitHub access token with access to the repository. It is recommended you put this token under secrets. |
+| `workflow_file_name` | True     | N/A     | File in .github/workflows to run (e.g. 'build.yaml')                                                   |
+| `github_user`        | False    | N/A     | GitHub user whose access token is being used to trigger the workflow.                                  |
+| `ref`                | False    | main    | git reference (e.g. branch, tag, or commit SHA) for the workflow run.                                  |
+| `wait_interval`      | False    | 10      | Delay (in seconds) between checks for result of run.                                                   |
+| `client_payload`     | False    | `{}`    | Payload to pass to the workflow, must be a JSON string                                                 |
+| `propagate_failure`  | False    | `true`  | Fail current job if downstream job fails.                                                              |
+| `trigger_workflow`   | False    | `true`  | Trigger the specified workflow.                                                                        |
+| `wait_workflow`      | False    | `true`  | Wait for workflow to finish.                                                                           |
+| `summarize`          | False    | `false` | Print downstream job URL and ID to workflow job summary.                                               |
 
 ## Example
 

--- a/trigger-workflow-and-wait/README.md
+++ b/trigger-workflow-and-wait/README.md
@@ -1,0 +1,115 @@
+# Trigger Workflow and Wait
+
+Github Action for trigger a workflow from another workflow. The action then waits for a response.
+
+**When would you use it?**
+
+When deploying an app you may need to deploy additional services, this Github Action helps with that.
+
+
+## Arguments
+
+| Argument Name            | Required   | Default     | Description           |
+| ---------------------    | ---------- | ----------- | --------------------- |
+| `owner`                  | True       | N/A         | The owner of the repository where the workflow is contained. |
+| `repo`                   | True       | N/A         | The repository where the workflow is contained. |
+| `github_token`           | True       | N/A         | The Github access token with access to the repository. Its recommended you put it under secrets. |
+| `workflow_file_name`     | True       | N/A         | The reference point. For example, you could use main.yml. |
+| `github_user`            | False      | N/A         | The name of the github user whose access token is being used to trigger the workflow. |
+| `ref`                    | False      | main        | The reference of the workflow run. The reference can be a branch, tag, or a commit SHA. |
+| `wait_interval`          | False      | 10          | The number of seconds delay between checking for result of run. |
+| `client_payload`         | False      | `{}`        | Payload to pass to the workflow, must be a JSON string |
+| `propagate_failure`      | False      | `true`      | Fail current job if downstream job fails. |
+| `trigger_workflow`       | False      | `true`      | Trigger the specified workflow. |
+| `wait_workflow`          | False      | `true`      | Wait for workflow to finish. |
+| `comment_downstream_url` | False      | ``          | A comments API URL to comment the current downstream job URL to. Default: no comment |
+| `comment_github_token`   | False      | `${{github.token}}`          | token used for pull_request comments |
+| `summarize`              | False      | `false`     | Print downstream job URL and ID to workflow job summary |
+
+
+## Example
+
+### Simple
+
+```yaml
+- uses: convictional/trigger-workflow-and-wait@v1.6.1
+  with:
+    owner: keithconvictional
+    repo: myrepo
+    github_token: ${{ secrets.GITHUB_PERSONAL_ACCESS_TOKEN }}
+```
+
+### All Options
+
+```yaml
+- uses: convictional/trigger-workflow-and-wait@v1.6.1
+  with:
+    owner: keithconvictional
+    repo: myrepo
+    github_token: ${{ secrets.GITHUB_PERSONAL_ACCESS_TOKEN }}
+    github_user: github-user
+    workflow_file_name: main.yml
+    ref: release-branch
+    wait_interval: 10
+    client_payload: '{}'
+    propagate_failure: false
+    trigger_workflow: true
+    wait_workflow: true
+```
+
+### Comment the current running workflow URL for a PR
+
+```yaml
+- uses: convictional/trigger-workflow-and-wait@v1.6.1
+  with:
+    owner: keithconvictional
+    repo: myrepo
+    github_token: ${{ secrets.GITHUB_PERSONAL_ACCESS_TOKEN }}
+    comment_downstream_url: ${{ github.event.pull_request.comments_url }}
+```
+
+## Testing
+
+You can test out the action locally by cloning the repository to your computer. You can run:
+
+```shell
+INPUT_OWNER="keithconvictional" \
+INPUT_REPO="myrepo" \
+INPUT_GITHUB_TOKEN="<REDACTED>" \
+INPUT_GITHUB_USER="github-user" \
+INPUT_WORKFLOW_FILE_NAME="main.yml" \
+INPUT_REF="release-branch" \
+INPUT_WAIT_INTERVAL=10 \
+INPUT_CLIENT_PAYLOAD='{}' \
+INPUT_PROPAGATE_FAILURE=false \
+INPUT_TRIGGER_WORKFLOW=true \
+INPUT_WAIT_WORKFLOW=true \
+busybox sh entrypoint.sh
+```
+
+You will have to create a Github Personal access token. You can create a test workflow to be executed. In a repository, add a new `main.yml` to `.github/workflows/`. The workflow will be:
+
+```shell
+name: Main
+on:
+  workflow_dispatch
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Pause for 25 seconds
+        run: |
+          sleep 25
+```
+
+You can see the example [here](https://github.com/keithconvictional/trigger-workflow-and-wait-example-repo1/blob/master/.github/workflows/main.yml). For testing a failure case, just add this line after the sleep:
+
+```yaml
+...
+- name: Pause for 25 seconds
+  run: |
+    sleep 25
+    echo "For testing failure"
+    exit 1
+```

--- a/trigger-workflow-and-wait/README.md
+++ b/trigger-workflow-and-wait/README.md
@@ -113,3 +113,9 @@ You can see the example [here](https://github.com/keithconvictional/trigger-work
     echo "For testing failure"
     exit 1
 ```
+
+## History
+
+> [!NOTE]
+> This action contains RAPIDs-specific commits on top of the archived project `convictional/trigger-workflow-and-wait` [link](https://github.com/convictional/trigger-workflow-and-wait).
+> For details, see https://github.com/rapidsai/workflows/issues/118

--- a/trigger-workflow-and-wait/README.md
+++ b/trigger-workflow-and-wait/README.md
@@ -2,11 +2,6 @@
 
 Github Action for trigger a workflow from another workflow. The action then waits for a response.
 
-**When would you use it?**
-
-When deploying an app you may need to deploy additional services, this Github Action helps with that.
-
-
 ## Arguments
 
 | Argument Name            | Required   | Default     | Description           |
@@ -26,92 +21,47 @@ When deploying an app you may need to deploy additional services, this Github Ac
 | `comment_github_token`   | False      | `${{github.token}}`          | token used for pull_request comments |
 | `summarize`              | False      | `false`     | Print downstream job URL and ID to workflow job summary |
 
-
 ## Example
 
-### Simple
+From https://github.com/rapidsai/workflows
 
 ```yaml
-- uses: convictional/trigger-workflow-and-wait@v1.6.1
+- uses: rapidsai/shared-actions/trigger-workflow-and-wait@main
   with:
-    owner: keithconvictional
-    repo: myrepo
-    github_token: ${{ secrets.GITHUB_PERSONAL_ACCESS_TOKEN }}
-```
-
-### All Options
-
-```yaml
-- uses: convictional/trigger-workflow-and-wait@v1.6.1
-  with:
-    owner: keithconvictional
-    repo: myrepo
-    github_token: ${{ secrets.GITHUB_PERSONAL_ACCESS_TOKEN }}
-    github_user: github-user
-    workflow_file_name: main.yml
-    ref: release-branch
-    wait_interval: 10
-    client_payload: '{}'
-    propagate_failure: false
+    owner: rapidsai
+    repo: rmm
+    github_token: ${{ secrets.WORKFLOW_TOKEN }}
+    github_user: GPUtester
+    workflow_file_name: build.yaml
+    ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+    wait_interval: 120
+    client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.rmm) }}
+    propagate_failure: true
     trigger_workflow: true
     wait_workflow: true
 ```
 
-### Comment the current running workflow URL for a PR
-
-```yaml
-- uses: convictional/trigger-workflow-and-wait@v1.6.1
-  with:
-    owner: keithconvictional
-    repo: myrepo
-    github_token: ${{ secrets.GITHUB_PERSONAL_ACCESS_TOKEN }}
-    comment_downstream_url: ${{ github.event.pull_request.comments_url }}
-```
-
 ## Testing
 
-You can test out the action locally by cloning the repository to your computer. You can run:
+To test locally:
 
 ```shell
-INPUT_OWNER="keithconvictional" \
-INPUT_REPO="myrepo" \
-INPUT_GITHUB_TOKEN="<REDACTED>" \
-INPUT_GITHUB_USER="github-user" \
-INPUT_WORKFLOW_FILE_NAME="main.yml" \
-INPUT_REF="release-branch" \
+INPUT_OWNER="rapidsai" \
+INPUT_REPO="rmm" \
+INPUT_GITHUB_TOKEN="$(gh auth token)" \
+INPUT_GITHUB_USER="GPUtester" \
+INPUT_WORKFLOW_FILE_NAME="build.yaml" \
+INPUT_REF="main" \
 INPUT_WAIT_INTERVAL=10 \
-INPUT_CLIENT_PAYLOAD='{}' \
-INPUT_PROPAGATE_FAILURE=false \
+INPUT_CLIENT_PAYLOAD="{
+    \"branch\": \"main\",
+    \"date\": \"$(date +%Y-%m-%d)\",
+    \"sha\": \"$(git ls-remote https://github.com/rapidsai/rmm.git refs/heads/main | cut -f1)\"
+}" \
+INPUT_PROPAGATE_FAILURE=true \
 INPUT_TRIGGER_WORKFLOW=true \
 INPUT_WAIT_WORKFLOW=true \
-busybox sh entrypoint.sh
-```
-
-You will have to create a Github Personal access token. You can create a test workflow to be executed. In a repository, add a new `main.yml` to `.github/workflows/`. The workflow will be:
-
-```shell
-name: Main
-on:
-  workflow_dispatch
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@master
-      - name: Pause for 25 seconds
-        run: |
-          sleep 25
-```
-
-You can see the example [here](https://github.com/keithconvictional/trigger-workflow-and-wait-example-repo1/blob/master/.github/workflows/main.yml). For testing a failure case, just add this line after the sleep:
-
-```yaml
-...
-- name: Pause for 25 seconds
-  run: |
-    sleep 25
-    echo "For testing failure"
-    exit 1
+bash entrypoint.sh
 ```
 
 ## History

--- a/trigger-workflow-and-wait/README.md
+++ b/trigger-workflow-and-wait/README.md
@@ -1,24 +1,22 @@
 # Trigger Workflow and Wait
 
-Github Action for trigger a workflow from another workflow. The action then waits for a response.
+GitHub Action for trigger a workflow from another workflow. The action then waits for a response.
 
-## Arguments
+## Inputs
 
-| Argument Name            | Required   | Default     | Description           |
+| Input Name            | Required   | Default     | Description           |
 | ---------------------    | ---------- | ----------- | --------------------- |
 | `owner`                  | True       | N/A         | The owner of the repository where the workflow is contained. |
 | `repo`                   | True       | N/A         | The repository where the workflow is contained. |
-| `github_token`           | True       | N/A         | The Github access token with access to the repository. Its recommended you put it under secrets. |
+| `github_token`           | True       | N/A         | The GitHub access token with access to the repository. Its recommended you put it under secrets. |
 | `workflow_file_name`     | True       | N/A         | The reference point. For example, you could use main.yml. |
-| `github_user`            | False      | N/A         | The name of the github user whose access token is being used to trigger the workflow. |
+| `github_user`            | False      | N/A         | The name of the GitHub user whose access token is being used to trigger the workflow. |
 | `ref`                    | False      | main        | The reference of the workflow run. The reference can be a branch, tag, or a commit SHA. |
 | `wait_interval`          | False      | 10          | The number of seconds delay between checking for result of run. |
 | `client_payload`         | False      | `{}`        | Payload to pass to the workflow, must be a JSON string |
 | `propagate_failure`      | False      | `true`      | Fail current job if downstream job fails. |
 | `trigger_workflow`       | False      | `true`      | Trigger the specified workflow. |
 | `wait_workflow`          | False      | `true`      | Wait for workflow to finish. |
-| `comment_downstream_url` | False      | ``          | A comments API URL to comment the current downstream job URL to. Default: no comment |
-| `comment_github_token`   | False      | `${{github.token}}`          | token used for pull_request comments |
 | `summarize`              | False      | `false`     | Print downstream job URL and ID to workflow job summary |
 
 ## Example
@@ -67,5 +65,5 @@ bash entrypoint.sh
 ## History
 
 > [!NOTE]
-> This action contains RAPIDs-specific commits on top of the archived project `convictional/trigger-workflow-and-wait` [link](https://github.com/convictional/trigger-workflow-and-wait).
+> This action contains NVIDIA-specific commits on top of the archived project `convictional/trigger-workflow-and-wait` [link](https://github.com/convictional/trigger-workflow-and-wait).
 > For details, see https://github.com/rapidsai/workflows/issues/118

--- a/trigger-workflow-and-wait/action.yml
+++ b/trigger-workflow-and-wait/action.yml
@@ -1,47 +1,39 @@
 name: 'Trigger Workflow and Wait'
-description: 'This action triggers a workflow in another repository and waits for the result.'
+description: 'Trigger a workflow in another repository and wait for the result.'
 inputs:
   owner:
-    description: "The owner of the repository where the workflow is contained."
+    description: "Owner of the repository where the workflow is contained."
     required: true
   repo:
-    description: "The repository where the workflow is contained."
+    description: "Repository where the workflow is contained."
     required: true
   github_token:
-    description: "The Github access token with access to the repository. It is recommended you put this token under secrets."
+    description: "GitHub access token with access to the repository. It is recommended you put this token under secrets."
     required: true
   github_user:
-    description: "The name of the github user whose access token is being used to trigger the workflow."
+    description: "GitHub user whose access token is being used to trigger the workflow."
     required: false
   ref:
-    description: 'The reference of the workflow run. The reference can be a branch, tag, or a commit SHA. Default: main'
+    description: 'git reference (e.g. branch, tag, or commit SHA) for the workflow run. Default: main'
     required: false
   wait_interval:
-    description: "The number of seconds delay between checking for result of run."
+    description: "Delay (in seconds) between checks for result of run."
     required: false
   workflow_file_name:
-    description: "The reference point. For example, you could use main.yml."
+    description: "File in .github/workflows to run (e.g. 'build.yaml')"
     required: true
   client_payload:
-    description: 'Payload to pass to the workflow, must be a JSON string'
+    description: "Payload to pass to the workflow, must be a JSON string"
     required: false
   propagate_failure:
-    description: 'Fail current job if downstream job fails. default: true'
+    description: "Fail current job if downstream job fails. default: true"
     required: false
   trigger_workflow:
-    description: 'Trigger the specified workflow. default: true'
+    description: "Trigger the specified workflow. default: true"
     required: false
   wait_workflow:
-    description: 'Wait for workflow to finish. default: true'
+    description: "Wait for workflow to finish. default: true"
     required: false
-  comment_downstream_url:
-    description: 'Comment API link for commenting the downstream job URL'
-    required: false
-    default: ''
-  comment_github_token:
-    description: "The Github access token with access to the repository for comment URL. It is recommended you put this token under secrets."
-    required: false
-    default: ${{ github.token }}
   summarize:
     description: "Print downstream job URL and ID to workflow job summary. default: false"
     required: false
@@ -51,7 +43,7 @@ outputs:
   workflow_url:
     description: The URL of the workflow that was triggered by this action
   conclusion:
-    description: Conclusion of the job, i.e pass/failure
+    description: Conclusion of the job (see https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#steps-context for possible values).
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/trigger-workflow-and-wait/action.yml
+++ b/trigger-workflow-and-wait/action.yml
@@ -1,0 +1,61 @@
+name: 'Trigger Workflow and Wait'
+description: 'This action triggers a workflow in another repository and waits for the result.'
+author: 'Convictional'
+branding:
+  icon: 'arrow-right'
+  color: 'yellow'
+inputs:
+  owner:
+    description: "The owner of the repository where the workflow is contained."
+    required: true
+  repo:
+    description: "The repository where the workflow is contained."
+    required: true
+  github_token:
+    description: "The Github access token with access to the repository. It is recommended you put this token under secrets."
+    required: true
+  github_user:
+    description: "The name of the github user whose access token is being used to trigger the workflow."
+    required: false
+  ref:
+    description: 'The reference of the workflow run. The reference can be a branch, tag, or a commit SHA. Default: main'
+    required: false
+  wait_interval:
+    description: "The number of seconds delay between checking for result of run."
+    required: false
+  workflow_file_name:
+    description: "The reference point. For example, you could use main.yml."
+    required: true
+  client_payload:
+    description: 'Payload to pass to the workflow, must be a JSON string'
+    required: false
+  propagate_failure:
+    description: 'Fail current job if downstream job fails. default: true'
+    required: false
+  trigger_workflow:
+    description: 'Trigger the specified workflow. default: true'
+    required: false
+  wait_workflow:
+    description: 'Wait for workflow to finish. default: true'
+    required: false
+  comment_downstream_url:
+    description: 'Comment API link for commenting the downstream job URL'
+    required: false
+    default: ''
+  comment_github_token:
+    description: "The Github access token with access to the repository for comment URL. It is recommended you put this token under secrets."
+    required: false
+    default: ${{ github.token }}
+  summarize:
+    description: "Print downstream job URL and ID to workflow job summary. default: false"
+    required: false
+outputs:
+  workflow_id:
+    description: The ID of the workflow that was triggered by this action
+  workflow_url:
+    description: The URL of the workflow that was triggered by this action
+  conclusion:
+    description: Conclusion of the job, i.e pass/failure
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/trigger-workflow-and-wait/action.yml
+++ b/trigger-workflow-and-wait/action.yml
@@ -1,9 +1,5 @@
 name: 'Trigger Workflow and Wait'
 description: 'This action triggers a workflow in another repository and waits for the result.'
-author: 'Convictional'
-branding:
-  icon: 'arrow-right'
-  color: 'yellow'
 inputs:
   owner:
     description: "The owner of the repository where the workflow is contained."

--- a/trigger-workflow-and-wait/contribute.md
+++ b/trigger-workflow-and-wait/contribute.md
@@ -1,5 +1,0 @@
-# Contribute
-
-```shell
-docker build . -t trigger-workflow-and-wait
-```

--- a/trigger-workflow-and-wait/contribute.md
+++ b/trigger-workflow-and-wait/contribute.md
@@ -1,0 +1,5 @@
+# Contribute
+
+```shell
+docker build . -t trigger-workflow-and-wait
+```

--- a/trigger-workflow-and-wait/entrypoint.sh
+++ b/trigger-workflow-and-wait/entrypoint.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+set -e
+
+usage_docs() {
+  echo ""
+  echo "You can use this Github Action with:"
+  echo "- uses: convictional/trigger-workflow-and-wait"
+  echo "  with:"
+  echo "    owner: keithconvictional"
+  echo "    repo: myrepo"
+  echo "    github_token: \${{ secrets.GITHUB_PERSONAL_ACCESS_TOKEN }}"
+  echo "    workflow_file_name: main.yaml"
+}
+GITHUB_API_URL="${API_URL:-https://api.github.com}"
+GITHUB_SERVER_URL="${SERVER_URL:-https://github.com}"
+
+validate_args() {
+  wait_interval=10 # Waits for 10 seconds
+  if [ "${INPUT_WAIT_INTERVAL}" ]
+  then
+    wait_interval=${INPUT_WAIT_INTERVAL}
+  fi
+
+  propagate_failure=true
+  if [ -n "${INPUT_PROPAGATE_FAILURE}" ]
+  then
+    propagate_failure=${INPUT_PROPAGATE_FAILURE}
+  fi
+
+  trigger_workflow=true
+  if [ -n "${INPUT_TRIGGER_WORKFLOW}" ]
+  then
+    trigger_workflow=${INPUT_TRIGGER_WORKFLOW}
+  fi
+
+  wait_workflow=true
+  if [ -n "${INPUT_WAIT_WORKFLOW}" ]
+  then
+    wait_workflow=${INPUT_WAIT_WORKFLOW}
+  fi
+
+  summarize=false
+  if [ -n "${INPUT_SUMMARIZE}" ]
+  then
+    summarize=${INPUT_SUMMARIZE}
+  fi
+
+  if [ -z "${INPUT_OWNER}" ]
+  then
+    echo "Error: Owner is a required argument."
+    usage_docs
+    exit 1
+  fi
+
+  if [ -z "${INPUT_REPO}" ]
+  then
+    echo "Error: Repo is a required argument."
+    usage_docs
+    exit 1
+  fi
+
+  if [ -z "${INPUT_GITHUB_TOKEN}" ]
+  then
+    echo "Error: Github token is required. You can head over settings and"
+    echo "under developer, you can create a personal access tokens. The"
+    echo "token requires repo access."
+    usage_docs
+    exit 1
+  fi
+
+  if [ -z "${INPUT_WORKFLOW_FILE_NAME}" ]
+  then
+    echo "Error: Workflow File Name is required"
+    usage_docs
+    exit 1
+  fi
+
+  client_payload=$(echo '{}' | jq -c)
+  if [ "${INPUT_CLIENT_PAYLOAD}" ]
+  then
+    client_payload=$(echo "${INPUT_CLIENT_PAYLOAD}" | jq -c)
+  fi
+
+  ref="main"
+  if [ "$INPUT_REF" ]
+  then
+    ref="${INPUT_REF}"
+  fi
+}
+
+lets_wait() {
+  echo "Sleeping for ${wait_interval} seconds"
+  sleep "$wait_interval"
+}
+
+api() {
+  path=$1; shift
+  if response=$(curl --fail-with-body -sSL \
+      "${GITHUB_API_URL}/repos/${INPUT_OWNER}/${INPUT_REPO}/actions/$path" \
+      -H "Authorization: Bearer ${INPUT_GITHUB_TOKEN}" \
+      -H 'Accept: application/vnd.github.v3+json' \
+      -H 'Content-Type: application/json' \
+      "$@")
+  then
+    echo "$response"
+  else
+    echo >&2 "api failed:"
+    echo >&2 "path: $path"
+    echo >&2 "response: $response"
+    if [[ "$response" == *'"Server Error"'* ]]; then
+      echo "Server error - trying again"
+    else
+      exit 1
+    fi
+  fi
+}
+
+lets_wait() {
+  local interval=${1:-$wait_interval}
+  echo >&2 "Sleeping for $interval seconds"
+  sleep "$interval"
+}
+
+# Return the ids of the most recent workflow runs, optionally filtered by user
+get_workflow_runs() {
+  since=${1:?}
+  ref=${2:?}
+
+  query="event=workflow_dispatch&created=>=$since&branch=${ref}${INPUT_GITHUB_USER+&actor=}${INPUT_GITHUB_USER}&per_page=100"
+
+  echo "Getting workflow runs using query: ${query}" >&2
+
+  api "workflows/${INPUT_WORKFLOW_FILE_NAME}/runs?${query}" |
+  jq -r '.workflow_runs[].id' |
+  sort # Sort to ensure repeatable order, and lexicographically for compatibility with join
+}
+
+trigger_workflow() {
+  START_TIME=$(date +%s)
+  SINCE=$(date -u -Iseconds -d "@$((START_TIME - 120))") # Two minutes ago, to overcome clock skew
+
+  OLD_RUNS=$(get_workflow_runs "$SINCE" "$ref")
+
+  echo >&2 "Triggering workflow:"
+  echo >&2 "  workflows/${INPUT_WORKFLOW_FILE_NAME}/dispatches"
+  echo >&2 "  {\"ref\":\"${ref}\",\"inputs\":${client_payload}}"
+
+  api "workflows/${INPUT_WORKFLOW_FILE_NAME}/dispatches" \
+    --data "{\"ref\":\"${ref}\",\"inputs\":${client_payload}}"
+
+  NEW_RUNS=$OLD_RUNS
+  while [ "$NEW_RUNS" = "$OLD_RUNS" ]
+  do
+    lets_wait
+    NEW_RUNS=$(get_workflow_runs "$SINCE" "$ref")
+  done
+
+  # Return new run ids
+  join -v2 <(echo "$OLD_RUNS") <(echo "$NEW_RUNS")
+}
+
+comment_downstream_link() {
+  if response=$(curl --fail-with-body -sSL -X POST \
+      "${INPUT_COMMENT_DOWNSTREAM_URL}" \
+      -H "Authorization: Bearer ${INPUT_COMMENT_GITHUB_TOKEN}" \
+      -H 'Accept: application/vnd.github.v3+json' \
+      -d "{\"body\": \"Running downstream job at $1\"}")
+  then
+    echo "$response"
+  else
+    echo >&2 "failed to comment to ${INPUT_COMMENT_DOWNSTREAM_URL}:"
+  fi
+}
+
+wait_for_workflow_to_finish() {
+  last_workflow_id=${1:?}
+  last_workflow_url="${GITHUB_SERVER_URL}/${INPUT_OWNER}/${INPUT_REPO}/actions/runs/${last_workflow_id}"
+
+  echo "Waiting for workflow to finish:"
+  echo "The workflow id is [${last_workflow_id}]."
+  echo "The workflow logs can be found at ${last_workflow_url}"
+  echo "workflow_id=${last_workflow_id}" >> $GITHUB_OUTPUT
+  echo "workflow_url=${last_workflow_url}" >> $GITHUB_OUTPUT
+  echo ""
+
+  if [ -n "${INPUT_COMMENT_DOWNSTREAM_URL}" ]; then
+    comment_downstream_link ${last_workflow_url}
+  fi
+
+  if [ "${summarize}" = true ]
+  then
+    echo "| | |" >> $GITHUB_STEP_SUMMARY
+    echo "| --- | --- |" >> $GITHUB_STEP_SUMMARY
+    echo "| Workflow URL | <${last_workflow_url}> |" >> $GITHUB_STEP_SUMMARY
+    echo "| Workflow ID | ${last_workflow_id} |" >> $GITHUB_STEP_SUMMARY
+    echo "| | |" >> $GITHUB_STEP_SUMMARY
+  fi
+
+  conclusion=null
+  status=
+
+  while [[ "${conclusion}" == "null" && "${status}" != "completed" ]]
+  do
+    lets_wait
+
+    workflow=$(api "runs/$last_workflow_id")
+    conclusion=$(echo "${workflow}" | jq -r '.conclusion')
+    status=$(echo "${workflow}" | jq -r '.status')
+
+    echo "Checking conclusion [${conclusion}]"
+    echo "Checking status [${status}]"
+    echo "Workflow logs: ${last_workflow_url}"
+    echo "conclusion=${conclusion}" >> $GITHUB_OUTPUT
+  done
+
+  if [[ "${conclusion}" == "success" && "${status}" == "completed" ]]
+  then
+    echo "Yes, success"
+  else
+    # Alternative "failure"
+    echo "Conclusion is not success, it's [${conclusion}]."
+
+    if [ "${propagate_failure}" = true ]
+    then
+      echo "Propagating failure to upstream job"
+      exit 1
+    fi
+  fi
+}
+
+main() {
+  validate_args
+
+  if [ "${trigger_workflow}" = true ]
+  then
+    run_ids=$(trigger_workflow)
+  else
+    echo "Skipping triggering the workflow."
+  fi
+
+  if [ "${wait_workflow}" = true ]
+  then
+    for run_id in $run_ids
+    do
+      wait_for_workflow_to_finish "$run_id"
+    done
+  else
+    echo "Skipping waiting for workflow."
+  fi
+}
+
+main

--- a/trigger-workflow-and-wait/entrypoint.sh
+++ b/trigger-workflow-and-wait/entrypoint.sh
@@ -6,12 +6,12 @@ set -e
 usage_docs() {
   echo ""
   echo "You can use this Github Action with:"
-  echo "- uses: convictional/trigger-workflow-and-wait"
+  echo "- uses: rapidsai/shared-actions/trigger-workflow-and-wait"
   echo "  with:"
-  echo "    owner: keithconvictional"
-  echo "    repo: myrepo"
+  echo "    owner: rapidsai"
+  echo "    repo: rmm"
   echo "    github_token: \${{ secrets.GITHUB_PERSONAL_ACCESS_TOKEN }}"
-  echo "    workflow_file_name: main.yaml"
+  echo "    workflow_file_name: build.yaml"
 }
 GITHUB_API_URL="${API_URL:-https://api.github.com}"
 GITHUB_SERVER_URL="${SERVER_URL:-https://github.com}"

--- a/trigger-workflow-and-wait/entrypoint.sh
+++ b/trigger-workflow-and-wait/entrypoint.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 set -e
 
 usage_docs() {

--- a/trigger-workflow-and-wait/entrypoint.sh
+++ b/trigger-workflow-and-wait/entrypoint.sh
@@ -5,7 +5,8 @@ set -e
 
 usage_docs() {
   echo ""
-  echo "You can use this Github Action with:"
+  echo "Usage:"
+  echo ""
   echo "- uses: rapidsai/shared-actions/trigger-workflow-and-wait"
   echo "  with:"
   echo "    owner: rapidsai"
@@ -49,30 +50,28 @@ validate_args() {
 
   if [ -z "${INPUT_OWNER}" ]
   then
-    echo "Error: Owner is a required argument."
+    echo "Error: 'owner' input is required."
     usage_docs
     exit 1
   fi
 
   if [ -z "${INPUT_REPO}" ]
   then
-    echo "Error: Repo is a required argument."
+    echo "Error: 'repo' input is required."
     usage_docs
     exit 1
   fi
 
   if [ -z "${INPUT_GITHUB_TOKEN}" ]
   then
-    echo "Error: Github token is required. You can head over settings and"
-    echo "under developer, you can create a personal access tokens. The"
-    echo "token requires repo access."
+    echo "Error: 'github_token' input is required."
     usage_docs
     exit 1
   fi
 
   if [ -z "${INPUT_WORKFLOW_FILE_NAME}" ]
   then
-    echo "Error: Workflow File Name is required"
+    echo "Error: 'workflow_file_name' input is required."
     usage_docs
     exit 1
   fi
@@ -90,6 +89,7 @@ validate_args() {
   fi
 }
 
+# shellcheck disable=SC2329
 lets_wait() {
   echo "Sleeping for ${wait_interval} seconds"
   sleep "$wait_interval"
@@ -161,41 +161,25 @@ trigger_workflow() {
   join -v2 <(echo "$OLD_RUNS") <(echo "$NEW_RUNS")
 }
 
-comment_downstream_link() {
-  if response=$(curl --fail-with-body -sSL -X POST \
-      "${INPUT_COMMENT_DOWNSTREAM_URL}" \
-      -H "Authorization: Bearer ${INPUT_COMMENT_GITHUB_TOKEN}" \
-      -H 'Accept: application/vnd.github.v3+json' \
-      -d "{\"body\": \"Running downstream job at $1\"}")
-  then
-    echo "$response"
-  else
-    echo >&2 "failed to comment to ${INPUT_COMMENT_DOWNSTREAM_URL}:"
-  fi
-}
-
 wait_for_workflow_to_finish() {
   last_workflow_id=${1:?}
   last_workflow_url="${GITHUB_SERVER_URL}/${INPUT_OWNER}/${INPUT_REPO}/actions/runs/${last_workflow_id}"
 
   echo "Waiting for workflow to finish:"
-  echo "The workflow id is [${last_workflow_id}]."
-  echo "The workflow logs can be found at ${last_workflow_url}"
-  echo "workflow_id=${last_workflow_id}" >> $GITHUB_OUTPUT
-  echo "workflow_url=${last_workflow_url}" >> $GITHUB_OUTPUT
+  echo "workflow id: [${last_workflow_id}]"
+  echo "workflow logs: ${last_workflow_url}"
+  echo "workflow_id=${last_workflow_id}" >> "${GITHUB_OUTPUT}"
+  echo "workflow_url=${last_workflow_url}" >> "${GITHUB_OUTPUT}"
   echo ""
-
-  if [ -n "${INPUT_COMMENT_DOWNSTREAM_URL}" ]; then
-    comment_downstream_link ${last_workflow_url}
-  fi
 
   if [ "${summarize}" = true ]
   then
-    echo "| | |" >> $GITHUB_STEP_SUMMARY
-    echo "| --- | --- |" >> $GITHUB_STEP_SUMMARY
-    echo "| Workflow URL | <${last_workflow_url}> |" >> $GITHUB_STEP_SUMMARY
-    echo "| Workflow ID | ${last_workflow_id} |" >> $GITHUB_STEP_SUMMARY
-    echo "| | |" >> $GITHUB_STEP_SUMMARY
+    # shellcheck disable=SC2129
+    echo "| | |" >> "${GITHUB_STEP_SUMMARY}"
+    echo "| --- | --- |" >> "${GITHUB_STEP_SUMMARY}"
+    echo "| Workflow URL | <${last_workflow_url}> |" >> "${GITHUB_STEP_SUMMARY}"
+    echo "| Workflow ID | ${last_workflow_id} |" >> "${GITHUB_STEP_SUMMARY}"
+    echo "| | |" >> "${GITHUB_STEP_SUMMARY}"
   fi
 
   conclusion=null
@@ -212,15 +196,15 @@ wait_for_workflow_to_finish() {
     echo "Checking conclusion [${conclusion}]"
     echo "Checking status [${status}]"
     echo "Workflow logs: ${last_workflow_url}"
-    echo "conclusion=${conclusion}" >> $GITHUB_OUTPUT
+    echo "conclusion=${conclusion}" >> "${GITHUB_OUTPUT}"
   done
 
   if [[ "${conclusion}" == "success" && "${status}" == "completed" ]]
   then
-    echo "Yes, success"
+    echo "Workflow succeeded."
   else
     # Alternative "failure"
-    echo "Conclusion is not success, it's [${conclusion}]."
+    echo "Conclusion is not 'success', it's [${conclusion}]."
 
     if [ "${propagate_failure}" = true ]
     then


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/workflows/issues/118

Vendors https://github.com/rapidsai/trigger-workflow-and-wait in here, so that repo can be archived. See the issue for details on the benefits of that.

## Notes for Reviewers

### I've intentionally structured the commits

In order:

1. https://github.com/rapidsai/shared-actions/commit/0b05d5d69c6d4bbaee2df4de931230f832b569ff = vendor without modification
2. https://github.com/rapidsai/shared-actions/commit/653df5987f453c45320634da1c280a621a5282fa = NVIDIA copyrights, licensing, ownership
3. https://github.com/rapidsai/shared-actions/commit/242452437537c06ebe46d7dcd689b6c8d440a033 = RAPIDS-ifying (removing unnecessary-to-us stuff, updating examples to point to RAPIDS things)

This PR can be squash merged, but just structured the commits that way for ease of reviewing.

### How I tested this

Ran the testing instructions in the README locally, saw them successfully trigger a `build.yaml` run in RMM.

Tried manually triggering a nightly pipeline with this in https://github.com/rapidsai/workflows/pull/119, saw it all appear to work well.