### PR TITLE
renovate: wait 7 days before taking updates, group updates together

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,21 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "enabled": false,
+      "matchPackageNames": [
+        "/^rapidsai//"
+      ],
+      "minimumReleaseAge": "7 days"
+    },
+    {
+      "matchManagers": [
+        "github-actions"
+      ],
+      "groupName": "github-actions",
+      "minimumReleaseAge": "7 days"
+    }
   ]
 }


### PR DESCRIPTION
Followup to https://github.com/rapidsai/shared-actions/pull/113#pullrequestreview-4414773060

Similar to https://github.com/rapidsai/shared-workflows/pull/526, proposes the following updates for `renovate` config here:

* apply a "cooldown" (do not take updates until they've been out for at least 7 days)
* group all updates together (yay fewer PRs)