### PR TITLE
feat(renovate): add 7-day cooldown before any updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,18 +5,23 @@
   ],
   "packageRules": [
     {
+      "description": "Wait for 7 days post-release before updating",
+      "matchPackageNames": [
+        "*"
+      ],
+      "minimumReleaseAge": "7 days"
+    },
+    {
       "enabled": false,
       "matchPackageNames": [
         "/^rapidsai//"
-      ],
-      "minimumReleaseAge": "7 days"
+      ]
     },
     {
       "matchManagers": [
         "github-actions"
       ],
-      "groupName": "github-actions",
-      "minimumReleaseAge": "7 days"
+      "groupName": "github-actions"
     }
   ]
 }


### PR DESCRIPTION
Part of rapidsai/build-planning#273

Adds a 7-day cooldown period before renovate proposes any updates