### PR TITLE
X-ORG-123: publish-docs action

### DIFF
--- a/publish-docs/README.md
+++ b/publish-docs/README.md
@@ -1,0 +1,58 @@
+# Publish Docs Action
+
+GitHub Action for publishing documentation to S3 and flushing the Akamai CDN cache.
+
+The action syncs a local docs directory to an S3 bucket, then submits an Akamai ECCU flush request so the updated content is served from `docs.nvidia.com`.
+
+## Inputs
+
+| Input Name | Required | Default | Description |
+| --- | --- | --- | --- |
+| `akamai-access-token` | Yes | N/A | Akamai EdgeGrid access token |
+| `akamai-client-secret` | Yes | N/A | Akamai EdgeGrid client secret |
+| `akamai-client-token` | Yes | N/A | Akamai EdgeGrid client token |
+| `akamai-emails-to-notify` | Yes | N/A | Comma-delimited email addresses to notify for Akamai flush request progress |
+| `akamai-host` | Yes | N/A | Akamai API hostname |
+| `akamai-request-name` | Yes | N/A | Name of the Akamai flush request |
+| `dry-run` | No | `false` | If `true`, run without making any changes |
+| `source-path` | Yes | N/A | Local path to the docs to publish |
+| `target-aws-access-key-id` | Yes | N/A | AWS access key ID |
+| `target-aws-region` | Yes | N/A | AWS region |
+| `target-aws-role-to-assume` | Yes | N/A | AWS role to assume |
+| `target-aws-secret-access-key` | Yes | N/A | AWS secret access key |
+| `target-s3-bucket` | Yes | N/A | The S3 bucket to upload files to |
+| `target-s3-key` | Yes | N/A | The S3 key to upload files to |
+| `target-s3-key-prefix` | No | `developer/docs` | Prefix prepended to `target-s3-key` |
+| `target-s3-key-suffix` | No | `""` | Suffix appended to `target-s3-key` |
+
+### S3 destination path
+
+The final S3 destination is constructed as:
+
+```
+s3://<target-s3-bucket>/<target-s3-key-prefix>/<target-s3-key>/<target-s3-key-suffix>
+```
+
+Leading and trailing slashes are stripped from each component before joining. Prefix and suffix are omitted from the path when empty.
+
+## Example
+
+```yaml
+- uses: rapidsai/shared-actions/publish-docs@main
+  with:
+    akamai-access-token: ${{ secrets.AKAMAI_ACCESS_TOKEN }}
+    akamai-client-secret: ${{ secrets.AKAMAI_CLIENT_SECRET }}
+    akamai-client-token: ${{ secrets.AKAMAI_CLIENT_TOKEN }}
+    akamai-emails-to-notify: docs-notify@example.com
+    akamai-host: ${{ secrets.AKAMAI_HOST }}
+    akamai-request-name: flush-${{ github.event.repository.name }}-${{ github.ref_name }}
+    dry-run: false
+    source-path: docs/_build/html
+    target-aws-access-key-id: ${{ secrets.DOCS_AWS_ACCESS_KEY_ID }}
+    target-aws-region: us-east-1
+    target-aws-role-to-assume: ${{ secrets.DOCS_AWS_ROLE_TO_ASSUME }}
+    target-aws-secret-access-key: ${{ secrets.DOCS_AWS_SECRET_ACCESS_KEY }}
+    target-s3-bucket: ${{ secrets.DOCS_S3_BUCKET }}
+    target-s3-key: ${{ github.event.repository.name }}
+    target-s3-key-suffix: nightly
+```

--- a/publish-docs/action.yml
+++ b/publish-docs/action.yml
@@ -1,0 +1,181 @@
+name: Publish Docs
+description: Publish documentation to S3
+
+inputs:
+  akamai-access-token:
+    description: Akamai EdgeGrid access token
+    required: true
+    type: string
+  akamai-client-token:
+    description: Akamai EdgeGrid client token
+    required: true
+    type: string
+  akamai-client-secret:
+    description: Akamai EdgeGrid client secret
+    required: true
+    type: string
+  akamai-emails-to-notify:
+    description: Email addresses to notify for Akamai flush request progress, comma-delimited
+    required: true
+    type: string
+  akamai-host:
+    description: Akamai API hostname
+    required: true
+    type: string
+  akamai-request-name:
+    description: Name of the Akamai flush request
+    required: true
+    type: string
+  dry-run:
+    default: "false"
+    description: If true, run without making any changes.
+    required: false
+    type: boolean
+  source-path:
+    description: Local location of the docs
+    required: true
+    type: string
+  target-aws-access-key-id:
+    description: AWS access key ID
+    required: true
+    type: string
+  target-aws-region:
+    description: AWS region
+    required: true
+    type: string
+  target-aws-role-to-assume:
+    description: AWS role to assume
+    required: true
+    type: string
+  target-aws-secret-access-key:
+    description: AWS secret access key
+    required: true
+    type: string
+  target-s3-bucket:
+    description: The S3 bucket to upload files to
+    required: true
+    type: string
+  target-s3-key:
+    description: The S3 key to upload files to
+    required: true
+    type: string
+  target-s3-key-prefix:
+    default: "developer/docs"
+    description: Prefix for the S3 key to upload files to
+    required: false
+    type: string
+  target-s3-key-suffix:
+    default: ""
+    description: Suffix for the S3 key to upload files to
+    required: false
+    type: string
+
+outputs:
+
+runs:
+  using: composite
+  steps:
+    - name: Download gha-tools with git clone
+      run: |
+        git clone https://github.com/rapidsai/gha-tools.git -b main /tmp/gha-tools
+        echo "/tmp/gha-tools/tools" >> "${GITHUB_PATH}"
+      shell: bash
+
+    - name: Install dependencies
+      run: |
+        sudo rapids-retry apt-get install -y --no-install-recommends jq xsltproc
+        rapids-pip-retry install --upgrade pip
+        rapids-pip-retry install -q httpie-edgegrid  # for Akamai CDN
+      shell: bash
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+      with:
+        aws-access-key-id: ${{ inputs.target-aws-access-key-id }}
+        aws-secret-access-key: ${{ inputs.target-aws-secret-access-key }}
+        aws-region: ${{ inputs.target-aws-region }}
+        role-to-assume: ${{ inputs.target-aws-role-to-assume }}
+
+    - name: Normalize S3 location
+      env:
+        S3_BUCKET: ${{ inputs.target-s3-bucket }}
+        S3_KEY: ${{ inputs.target-s3-key }}
+        S3_KEY_PREFIX: ${{ inputs.target-s3-key-prefix }}
+        S3_KEY_SUFFIX: ${{ inputs.target-s3-key-suffix }}
+      id: normalize-s3-location
+      run: |
+        S3_BUCKET="${S3_BUCKET%/}"  # strip trailing slash
+        S3_BUCKET="${S3_BUCKET#/}"  # strip leading slash
+        S3_KEY="${S3_KEY%/}"        # strip trailing slash
+        S3_KEY="${S3_KEY#/}"        # strip leading slash
+        if [[ -n "${S3_KEY_PREFIX}" ]]; then
+          S3_KEY_PREFIX="${S3_KEY_PREFIX%/}"
+          S3_KEY_PREFIX="${S3_KEY_PREFIX#/}"
+          S3_KEY="${S3_KEY_PREFIX}/${S3_KEY}"
+        fi
+        if [[ -n "${S3_KEY_SUFFIX}" ]]; then
+          S3_KEY_SUFFIX="${S3_KEY_SUFFIX%/}"
+          S3_KEY_SUFFIX="${S3_KEY_SUFFIX#/}"
+          S3_KEY="${S3_KEY}/${S3_KEY_SUFFIX}"
+        fi
+        echo "target-s3-bucket=${S3_BUCKET}" >> "$GITHUB_OUTPUT"
+        echo "target-s3-key=${S3_KEY}" >> "$GITHUB_OUTPUT"
+      shell: bash
+
+    - name: Publish docs
+      env:
+        S3_BUCKET: ${{ steps.normalize-s3-location.outputs.target-s3-bucket }}
+        S3_KEY: ${{ steps.normalize-s3-location.outputs.target-s3-key }}
+      if: ${{ inputs.dry-run == 'false' }}
+      run: |
+        aws s3 sync . "s3://$S3_BUCKET/$S3_KEY" --delete
+      shell: bash
+      working-directory: ${{ inputs.source-path }}
+
+    - name: Create Akamai .edgerc file
+      env:
+        AKAMAI_ACCESS_TOKEN: ${{ inputs.akamai-access-token }}
+        AKAMAI_CLIENT_SECRET: ${{ inputs.akamai-client-secret }}
+        AKAMAI_CLIENT_TOKEN: ${{ inputs.akamai-client-token }}
+        AKAMAI_HOST: ${{ inputs.akamai-host }}
+        EDGERC_TEMPLATE: ${{ github.action_path }}/edgerc.template
+      run: |
+        envsubst < "${EDGERC_TEMPLATE}" > ~/.edgerc
+      shell: bash
+
+    - name: Create Akamai ECCU flush request XML
+      env:
+        S3_PATH: ${{ steps.normalize-s3-location.outputs.target-s3-key }}
+        XSLT_TEMPLATE: ${{ github.action_path }}/akamai-eccu-flush.xslt
+      run: |
+        xsltproc --stringparam target-path "${S3_PATH}" "${XSLT_TEMPLATE}" "${XSLT_TEMPLATE}" | \
+          sed 's/xmlns:match="x" //' > /tmp/flush.xml
+        cat /tmp/flush.xml
+      shell: bash
+
+    - name: Create email-addresses.json
+      env:
+        AKAMAI_EMAILS_TO_NOTIFY: ${{ inputs.akamai-emails-to-notify }}
+      run: |
+        echo -n "${AKAMAI_EMAILS_TO_NOTIFY}" | jq -Rc 'split(",")' > /tmp/email-addresses.json
+      shell: bash
+
+    - name: Submit Akamai ECCU flush request
+      env:
+        AKAMAI_REQUEST_NAME: ${{ inputs.akamai-request-name }}
+      if: ${{ inputs.dry-run == 'false' }}
+      run: |
+        http --ignore-stdin --auth-type edgegrid -a default: :/eccu-api/v1/requests \
+          metadata=@/tmp/flush.xml \
+          propertyName=docs.nvidia.com \
+          propertyNameExactMatch=true \
+          propertyType=HOST_HEADER \
+          requestName="${AKAMAI_REQUEST_NAME}" \
+          statusUpdateEmails:=@/tmp/email-addresses.json
+      shell: bash
+
+    - name: Delete Akamai .edgerc file
+      if: always()
+      run: |
+        rm -f ~/.edgerc
+      shell: bash

--- a/publish-docs/akamai-eccu-flush.xslt
+++ b/publish-docs/akamai-eccu-flush.xslt
@@ -1,0 +1,62 @@
+<?xml-stylesheet type="text/xsl" href="akamai-eccu-flush.xslt"?>
+
+<!--
+  Akamai ECCU (Edge Content Control Utility) XML Generator
+  This XSLT template generates an ECCU request XML for flushing Akamai cache.
+  It takes a path parameter and recursively builds the directory structure
+  needed for the cache invalidation request.
+  Usage:
+    xsltproc -stringparam target-path "path/to/flush" akamai-eccu-flush.xslt akamai-eccu-flush.xslt
+  The output XML will contain nested match:recursive-dirs elements that
+  represent the path hierarchy for cache invalidation.
+-->
+
+<xsl:stylesheet xmlns:match="x"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                version="1.0"
+                exclude-result-prefixes="match">
+
+  <xsl:output method="xml" version="1.0" indent="yes"/>
+
+  <!-- Parameter: The path to flush in Akamai cache -->
+  <xsl:param name="target-path"/>
+
+  <!-- Root template: Create the ECCU wrapper -->
+  <xsl:template match="/">
+    <eccu>
+      <xsl:call-template name="dir">
+        <xsl:with-param name="dir" select="$target-path"/>
+      </xsl:call-template>
+    </eccu>
+  </xsl:template>
+
+  <!-- Recursive template: Build nested directory structure -->
+  <xsl:template name="dir">
+    <xsl:param name="dir"/>
+
+    <!-- Extract the first path segment before '/' -->
+    <xsl:variable name="path" select="substring-before($dir, '/')"/>
+
+    <!-- Get remaining path after the first '/' -->
+    <xsl:variable name="rest" select="substring-after($dir, '/')"/>
+
+    <xsl:choose>
+      <!-- If there are more path segments, recurse -->
+      <xsl:when test="string-length($rest) &gt; 0">
+        <match:recursive-dirs value="{$path}">
+          <xsl:call-template name="dir">
+            <xsl:with-param name="dir" select="$rest"/>
+          </xsl:call-template>
+        </match:recursive-dirs>
+      </xsl:when>
+
+      <!-- Final path segment: add revalidate directive -->
+      <xsl:otherwise>
+        <match:recursive-dirs value="{$dir}">
+          <revalidate>now</revalidate>
+        </match:recursive-dirs>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/publish-docs/edgerc.template
+++ b/publish-docs/edgerc.template
@@ -1,0 +1,5 @@
+[default]
+client_secret = ${AKAMAI_CLIENT_SECRET}
+host = ${AKAMAI_HOST}
+access_token = ${AKAMAI_ACCESS_TOKEN}
+client_token = ${AKAMAI_CLIENT_TOKEN}


### PR DESCRIPTION
Closes #123 

POC for a shared action to publish HTML docs to docs.nvidia.com, based off of work from https://github.com/NVIDIA-NeMo/FW-CI-templates/tree/main/.github/actions/publish-docs.

The action takes files local to the workspace, uploads them to location in the docs.nvidia.com S3 bucket, and then flushes the Akamai CDN for the corresponding cache path. (Most of our CI docs building jobs push to S3 from a tmp directory, and don't make pushing to an artifact simple - for now I'm gonna keep this action agnostic about where the HTML files come from.)

Unlike the NeMo action, this action _does not_ make any special determination about whether it should perform writes, and _does not_ make any special determination about the S3 path to write to.

I am intentionally leaving this as just a "dumb" IO action, pushing the logic for what/where/when to write back to the caller. We can always write another shared action / shared workflow that wraps this for orchestrating how branches/tags/versions are mapped to URLs.

I'd like to get this merged ASAP so I can integrate it into one of our repos and start flushing the bugs out.