### PR TITLE
X-ORG-123: Finesse publish-docs action more

### DIFF
--- a/publish-docs/README.md
+++ b/publish-docs/README.md
@@ -4,6 +4,8 @@ GitHub Action for publishing documentation to S3 and flushing the Akamai CDN cac
 
 The action syncs a local docs directory to an S3 bucket, then submits an Akamai ECCU flush request so the updated content is served from `docs.nvidia.com`.
 
+N.B. This action assumes it is being run inside a RAPIDS CI image.
+
 ## Inputs
 
 | Input Name | Required | Default | Description |

--- a/publish-docs/action.yml
+++ b/publish-docs/action.yml
@@ -43,10 +43,6 @@ inputs:
     description: AWS region
     required: true
     type: string
-  target-aws-role-to-assume:
-    description: AWS role to assume
-    required: true
-    type: string
   target-aws-secret-access-key:
     description: AWS secret access key
     required: true
@@ -75,15 +71,10 @@ outputs: {}
 runs:
   using: composite
   steps:
-    - name: Download gha-tools with git clone
-      run: |
-        git clone https://github.com/rapidsai/gha-tools.git -b main /tmp/gha-tools
-        echo "/tmp/gha-tools/tools" >> "${GITHUB_PATH}"
-      shell: bash
-
     - name: Install dependencies
       run: |
-        sudo rapids-retry apt-get install -y --no-install-recommends jq xsltproc
+        apt-get update
+        apt-get install -y --no-install-recommends jq xsltproc
         rapids-pip-retry install --upgrade pip
         rapids-pip-retry install -q httpie-edgegrid  # for Akamai CDN
       shell: bash
@@ -94,7 +85,7 @@ runs:
         aws-access-key-id: ${{ inputs.target-aws-access-key-id }}
         aws-secret-access-key: ${{ inputs.target-aws-secret-access-key }}
         aws-region: ${{ inputs.target-aws-region }}
-        role-to-assume: ${{ inputs.target-aws-role-to-assume }}
+        unset-current-credentials: true
 
     - name: Normalize S3 location
       env:
@@ -124,11 +115,15 @@ runs:
 
     - name: Uploads docs
       env:
+        DRY_RUN: ${{ inputs.dry-run }}
         S3_BUCKET: ${{ steps.normalize-s3-location.outputs.target-s3-bucket }}
         S3_KEY: ${{ steps.normalize-s3-location.outputs.target-s3-key }}
-      if: ${{ inputs.dry-run == 'false' }}
       run: |
-        aws s3 sync . "s3://$S3_BUCKET/$S3_KEY" --delete
+        DRY_RUN_FLAG=""
+        if [[ "$DRY_RUN" == "true" ]]; then
+          DRY_RUN_FLAG="--dryrun"
+        fi
+        aws s3 sync --delete $DRY_RUN_FLAG . "s3://$S3_BUCKET/$S3_KEY"
       shell: bash
       working-directory: ${{ inputs.source-path }}
 


### PR DESCRIPTION
Contributes to #123 

Misc fixes while getting https://github.com/rapidsai/shared-workflows/pull/600 operational:

- Back out installing gha-tools for now - we'll just run the action in a RAPIDS CI container
- Unset any existing AWS credentials when getting DXOPS credentials
- Back out trying to assume the IAM role
- Upload to S3 with `--dryrun` so we can monitor output