### PR TITLE
enforce 'yamllint' checks, update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: check-yaml
       - id: end-of-file-fixer
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.27.0
+    rev: v1.28.0
     hooks:
       - id: zizmor
   - repo: https://github.com/rhysd/actionlint
@@ -22,7 +22,7 @@ repos:
     hooks:
       - id: actionlint-docker
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.22
+    rev: v0.16.0
     hooks:
       - id: ruff-check
         args: ["--fix", "--config=pyproject.toml"]
@@ -47,3 +47,8 @@ repos:
     rev: v0.11.0.1
     hooks:
       - id: shellcheck
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.38.0
+    hooks:
+      - id: yamllint
+        additional_dependencies: [pyyaml]

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+extends: default
+
+rules:
+  anchors:
+    forbid-undeclared-aliases: true
+    forbid-duplicated-anchors: true
+    forbid-unused-anchors: true
+  braces:
+    forbid: false
+    min-spaces-inside: 0
+    # allow 1 space for jinja templating in conda recipes
+    max-spaces-inside: 1
+    min-spaces-inside-empty: -1
+    max-spaces-inside-empty: -1
+  brackets: enable
+  colons:
+    max-spaces-before: 0
+    max-spaces-after: 1
+  commas:
+    max-spaces-before: 0
+    min-spaces-after: 1
+    max-spaces-after: 1
+  comments: disable
+  comments-indentation: disable
+  document-end: disable
+  document-start: disable
+  key-duplicates:
+    forbid-duplicated-merge-keys: true
+  line-length: disable
+  truthy:
+    allowed-values: ['false', 'true']
+    # having problematic value in keys is rare... and also
+    # GitHub Actions' choie of 'on:' triggers this check
+    # ref: https://github.com/adrienverge/yamllint/issues/430
+    check-keys: false

--- a/telemetry-impls/set-otel-service-name/action.yml
+++ b/telemetry-impls/set-otel-service-name/action.yml
@@ -1,4 +1,3 @@
-
 name: set-otel-service-name
 description: |
     Set OTEL_SERVICE_NAME from github job info

--- a/telemetry-impls/stash-job-artifacts/action.yml
+++ b/telemetry-impls/stash-job-artifacts/action.yml
@@ -1,4 +1,3 @@
-
 name: stash-job-artifacts
 description: |
     Saves and uploads a file with telemetry attributes that should be attached to spans from this run.

--- a/telemetry-impls/traceparent/action.yml
+++ b/telemetry-impls/traceparent/action.yml
@@ -26,7 +26,7 @@ runs:
 
     - shell: bash
       id: output-inputs
-      if:  runner.debug == '1'
+      if: runner.debug == '1'
       run: |
         echo "::debug::trace ID input: '${GITHUB_REPOSITORY}+${GITHUB_RUN_ID}+${GITHUB_RUN_ATTEMPT}'"
         echo "::debug::$GITHUB_REPOSITORY="${GITHUB_REPOSITORY}""


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/305

Proposes enforcing `yamllint` checks here, to standardize formatting of YAML files and catch correctness issues.

Also updates all `pre-commit` hooks to their latest versions, might as well while we're using a CI run and a review.

Closes #122