### PR TITLE
X-ORG-123: publish-docs supports non-containerized runs

### DIFF
--- a/publish-docs/action.yml
+++ b/publish-docs/action.yml
@@ -73,9 +73,11 @@ runs:
   steps:
     - name: Install dependencies
       run: |
+        # Check if we're running inside a CI container
         if [ -f /.dockerenv ]; then
           apt-get update
           apt-get install -y --no-install-recommends jq xsltproc;
+        # Otherwise we'll need sudo
         else
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends jq xsltproc;

--- a/publish-docs/action.yml
+++ b/publish-docs/action.yml
@@ -73,8 +73,13 @@ runs:
   steps:
     - name: Install dependencies
       run: |
-        apt-get update
-        apt-get install -y --no-install-recommends jq xsltproc
+        if [ -f /.dockerenv ]; then
+          apt-get update
+          apt-get install -y --no-install-recommends jq xsltproc;
+        else
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends jq xsltproc;
+        fi
         rapids-pip-retry install --upgrade pip
         rapids-pip-retry install -q httpie-edgegrid  # for Akamai CDN
       shell: bash


### PR DESCRIPTION
Contributes to #123 

This action is typically used _inside_ a CI container, but https://github.com/rapidsai/deployment runs its build _outside_ of a CI container.

(N.B. I _tried_ to just use a CI container for that repo's workflow, but there are package issues with the Python version mismatch between what that repo expects, and what our recent CI images provide. Will come back to this later.)

Let's support doing the `apt-get install` in _either_ a container or not.