### PR TITLE
Make release output dispatch container-safe

### DIFF
--- a/release-build-output-dispatch/action.yml
+++ b/release-build-output-dispatch/action.yml
@@ -1,5 +1,5 @@
 name: Dispatch release build output
-description: Check out the selected shared-actions revision and create a release build-output companion.
+description: Create a release build-output companion from the selected shared-actions revision.
 
 inputs:
   artifact-type:
@@ -38,35 +38,74 @@ inputs:
 outputs:
   manifest-path:
     description: Absolute path to the generated manifest.
-    value: ${{ steps.release-build-output.outputs.manifest-path }}
+    value: ${{ steps.materialize.outputs.manifest-path }}
   metadata-path:
     description: Absolute path to the build metadata envelope.
-    value: ${{ steps.release-build-output.outputs.metadata-path }}
+    value: ${{ steps.materialize.outputs.metadata-path }}
   manifest-artifact-name:
     description: Name of the uploaded GitHub Actions companion artifact.
-    value: ${{ steps.release-build-output.outputs.manifest-artifact-name }}
+    value: ${{ steps.companion-name.outputs.name }}
 
 runs:
   using: composite
   steps:
-    - name: Check out shared-actions implementation
-      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - id: implementation
+      name: Resolve release build-output implementation
+      shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        HOST_WORKSPACE: ${{ github.workspace }}
+      run: |
+        host_root="$(dirname "$(dirname "${HOST_WORKSPACE}")")"
+        container_root="$(dirname "$(dirname "${PWD}")")"
+        action_path="${ACTION_PATH}"
+        if [[ ! -d "${action_path}" && "${action_path}" == "${host_root}/"* ]]; then
+          action_path="${container_root}/${action_path#"${host_root}/"}"
+        fi
+        implementation_path="$(dirname "${action_path}")/release-build-output"
+        if [[ ! -d "${implementation_path}" ]]; then
+          echo "release-build-output implementation not found at ${implementation_path}" >&2
+          exit 1
+        fi
+        echo "path=${implementation_path}" >>"${GITHUB_OUTPUT}"
+    - id: prepare
+      name: Describe release artifacts
+      shell: bash
+      env:
+        IMPLEMENTATION_PATH: ${{ steps.implementation.outputs.path }}
+        RELEASE_ARTIFACTS: ${{ inputs.release-artifacts }}
+        RELEASE_ARTIFACT_TYPE: ${{ inputs.artifact-type }}
+        RELEASE_OUTPUT_DIRECTORY: ${{ inputs.output-directory }}
+        RELEASE_PACKAGE: ${{ inputs.release-package }}
+        RELEASE_PACKAGE_FILE: ${{ inputs.release-package-file }}
+      run: "${IMPLEMENTATION_PATH}/prepare.sh"
+    - id: materialize
+      name: Materialize release build-output records
+      shell: bash
+      env:
+        IMPLEMENTATION_PATH: ${{ steps.implementation.outputs.path }}
+        RELEASE_ARTIFACTS: ${{ steps.prepare.outputs.artifacts }}
+        RELEASE_MANIFEST_NAME: ${{ inputs.manifest-name }}
+        RELEASE_METADATA_NAME: ${{ inputs.metadata-name }}
+        RELEASE_OUTPUT_DIRECTORY: ${{ inputs.output-directory }}
+        RELEASE_PACKAGE: ${{ steps.prepare.outputs.package }}
+        RELEASE_PACKAGE_FILE: ${{ inputs.release-package-file }}
+        RELEASE_SOURCE_ARTIFACT_NAME: ${{ inputs.source-artifact-name }}
+        RELEASE_SOURCE_SHA: ${{ inputs.source-sha || github.sha }}
+        RELEASE_UNIT: ${{ inputs.release-unit }}
+      run: "${IMPLEMENTATION_PATH}/materialize.sh"
+    - id: companion-name
+      name: Set companion artifact name
+      shell: bash
+      env:
+        SOURCE_ARTIFACT_NAME: ${{ inputs.source-artifact-name }}
+      run: echo "name=release-build-output-${SOURCE_ARTIFACT_NAME}" >>"${GITHUB_OUTPUT}"
+    - name: Upload release build-output companion
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        repository: ${{ env.SHARED_ACTIONS_REPO || github.action_repository || 'rapidsai/shared-actions' }}
-        ref: ${{ env.SHARED_ACTIONS_REF || github.action_ref || 'main' }}
-        path: ./shared-actions
-        persist-credentials: false
-    - id: release-build-output
-      name: Create release build-output companion
-      uses: ./shared-actions/release-build-output
-      with:
-        artifact-type: ${{ inputs.artifact-type }}
-        release-unit: ${{ inputs.release-unit }}
-        release-package: ${{ inputs.release-package }}
-        release-package-file: ${{ inputs.release-package-file }}
-        release-artifacts: ${{ inputs.release-artifacts }}
-        output-directory: ${{ inputs.output-directory }}
-        manifest-name: ${{ inputs.manifest-name }}
-        metadata-name: ${{ inputs.metadata-name }}
-        source-artifact-name: ${{ inputs.source-artifact-name }}
-        source-sha: ${{ inputs.source-sha }}
+        if-no-files-found: error
+        name: ${{ steps.companion-name.outputs.name }}
+        path: |
+          ${{ inputs.output-directory }}/${{ inputs.manifest-name }}
+          ${{ inputs.output-directory }}/${{ inputs.metadata-name }}
+          ${{ inputs.output-directory }}/release-evidence/**


### PR DESCRIPTION
**Posted by Codex (GPT-5) on behalf of [@msarahan](https://github.com/msarahan). This pull request is LLM-generated; readers should treat its content accordingly.**

## Summary

- keep the public `release-build-output-dispatch` interface unchanged
- run the checked-out implementation through workspace-relative shell steps
- upload the same manifest, metadata, provenance, and SBOM companion content

## Why

The dispatch action currently checks out `shared-actions` and then invokes a nested local action with `uses: ./shared-actions/release-build-output`. In container jobs, the runner can resolve that nested action against the host workspace path even though the checkout is visible at the container workspace path. This caused the nx-cugraph and KvikIO canaries to upload their package bundles but fail before uploading their release-build-output companions.

This change preserves the dispatch action as the remote entry point while avoiding nested local-action resolution across the host/container boundary.

## Validation

- `pre-commit run --files release-build-output-dispatch/action.yml`
- `git diff --check`

This is initially a draft and should not merge until the dependent shared-workflows and downstream canaries have been rerun against this branch.

Related to rapidsai/shared-workflows#609 and rapidsai/build-infra#381.
